### PR TITLE
fix: make ExceptionsManagerModule nullable

### DIFF
--- a/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
@@ -26,7 +26,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   private var resId: Int = -1
   private var url: String? = null
   private var shouldBeReloaded = true
-  private var exceptionManager: ExceptionsManagerModule
+  private var exceptionManager: ExceptionsManagerModule?
   private var isUserHandlingErrors = false
 
   enum class Events(private val mName: String) {
@@ -417,7 +417,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
     val errorMap = Arguments.createMap()
     errorMap.putString("message", message)
     errorMap.putArray("stack", createStackTraceForRN(error.stackTrace))
-    exceptionManager.reportException(errorMap)
+    exceptionManager?.reportException(errorMap)
 
   }
 


### PR DESCRIPTION
Getting the following errors when trying to build an android app:

```
e: .../node_modules/rive-react-native/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt: (48, 24): Type mismatch: inferred type is ExceptionsManagerModule? but ExceptionsManagerModule was expected
e: .../node_modules/rive-react-native/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt: (48, 50): Type mismatch: inferred type is ExceptionsManagerModule? but ExceptionsManagerModule was expected
```

Changing `ExceptionsManagerModule` to nullable to get this working