### PR TITLE
chore: bump rive-android release

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -136,6 +136,6 @@ dependencies {
   implementation 'androidx.core:core-ktx:1.3.2'
   implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
-  implementation 'app.rive:rive-android:0.2.15'
+  implementation 'app.rive:rive-android:0.2.16'
   implementation 'com.android.volley:volley:1.2.0'
 }


### PR DESCRIPTION
Updates rive-android to be the latest version, no fixes here just updating java/kotlin/gradle in android.