### PR TITLE
fix: prevent calling listener logic with potentially undefined coordinate values

### DIFF
--- a/src/Rive.tsx
+++ b/src/Rive.tsx
@@ -290,23 +290,27 @@ const RiveContainer = React.forwardRef<RiveRef, Props>(
     );
 
     const touchBegan = useCallback<RiveRef[ViewManagerMethod.touchBegan]>(
-      (x: Number, y: Number) => {
-        UIManager.dispatchViewManagerCommand(
-          findNodeHandle(riveRef.current),
-          ViewManagerMethod.touchBegan,
-          [x, y]
-        );
+      (x: number, y: number) => {
+        if (!isNaN(x) && !isNaN(y)) {
+          UIManager.dispatchViewManagerCommand(
+            findNodeHandle(riveRef.current),
+            ViewManagerMethod.touchBegan,
+            [x, y]
+          );
+        }
       },
       []
     );
 
     const touchEnded = useCallback<RiveRef[ViewManagerMethod.touchEnded]>(
-      (x: Number, y: Number) => {
-        UIManager.dispatchViewManagerCommand(
-          findNodeHandle(riveRef.current),
-          ViewManagerMethod.touchEnded,
-          [x, y]
-        );
+      (x: number, y: number) => {
+        if (!isNaN(x) && !isNaN(y)) {
+          UIManager.dispatchViewManagerCommand(
+            findNodeHandle(riveRef.current),
+            ViewManagerMethod.touchEnded,
+            [x, y]
+          );
+        }
       },
       []
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,8 @@ export type RiveRef = {
     areStateMachines?: boolean
   ) => void;
   reset: () => void;
-  touchBegan: (x: Number, y: Number) => void;
-  touchEnded: (x: Number, y: Number) => void;
+  touchBegan: (x: number, y: number) => void;
+  touchEnded: (x: number, y: number) => void;
 };
 
 export enum ViewManagerMethod {


### PR DESCRIPTION
Addresses #140  - for some reason, scrolling the Rive view is calling `onPressOut` with undefined coordinates, and thus causing issues at the iOS and most likely Android level too when we call into the native Listeners logic. Docs on React Native are a bit unclear as to the behavior around `onPressOut` and scrolling, so not quite sure why this is, but this should help fix things for now, safely.

