### PR TITLE
refactor: style sheet code

### DIFF
--- a/src/Rive.tsx
+++ b/src/Rive.tsx
@@ -376,13 +376,13 @@ const RiveContainer = React.forwardRef<RiveRef, Props>(
 );
 
 const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+  },
   children: {
     position: 'absolute',
     width: '100%',
     height: '100%',
-  },
-  container: {
-    flexGrow: 1,
   },
   animation: {
     flex: 1,


### PR DESCRIPTION
I noticed css keys order in const styles doesn't match the components flow which use the css keys. In RiveContainer component return code, style.container key is used first among the css keys, but the key order is the second in const style. It's better to make them in the same order for readablity. So I refactored it. Thank you!