### PR TITLE
fix(android): remove jcenter repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -55,7 +55,6 @@ android {
 repositories {
   mavenCentral()
   mavenLocal()
-  jcenter()
   google()
 
   def found = false

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:4.0.1"
@@ -22,6 +22,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
@@ -33,7 +34,6 @@ allprojects {
         }
 
         google()
-        jcenter()
         maven { url 'https://www.jitpack.io' }
     }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -19,4 +19,4 @@
 
 android.useAndroidX=true
 android.enableJetifier=true
-FLIPPER_VERSION=0.54.0
+FLIPPER_VERSION=0.99.0


### PR DESCRIPTION
On February 3 2021, JFrog [announced that they will be shutting down Bintray and JCenter](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)

So remove jcenter() and replace it with mavenCentral().

Upgrade also some necessary tools for react native like Flipper to version 0.99.