### PR TITLE
fix: remove if statement in publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,6 @@ on:
 jobs:
   publish:
     name: Install and publish
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
No longer needed in the manual dispatch workflow for publishing the NPM package