### PR TITLE
fix: Improve typing of the `style` prop

### DIFF
--- a/src/Rive.tsx
+++ b/src/Rive.tsx
@@ -9,6 +9,7 @@ import {
   View,
   TouchableWithoutFeedback,
   GestureResponderEvent,
+  StyleProp,
 } from 'react-native';
 import {
   RiveRef,
@@ -68,7 +69,7 @@ type RiveProps = {
   ref: any;
   resourceName?: string;
   url?: string;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
   testID?: string;
 };
 


### PR DESCRIPTION
This PR improves the typing of the `style` prop to accepts more complex styles.

Currently, the `style` prop is typed as `ViewStyle`, which only accepts style objects. However, it doesn't accept more complex styles such as:
* Registered styles, e.g. `style={StyleSheet.absoluteFill}`
* Combined styles, e.g. `style={[{ width: 300, height: 300}, pressed && { backgroundColor: "red }]}`

By changing the type to `StyleProp<ViewStyle>` the Rive component now accepts these constructs. Note that this is the type used by React Native's `<View>` component ([reference](https://github.com/facebook/react-native/blob/b2fda3eca756b0dee3bac807091a767abb7742bf/Libraries/Components/View/ViewPropTypes.d.ts#L234)).