### PR TITLE
Fix: update Android dependency to fix lifecycle issues

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -135,7 +135,7 @@ dependencies {
   implementation 'androidx.core:core-ktx:1.3.2'
   implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
-  implementation 'app.rive:rive-android:4.3.0'
+  implementation 'app.rive:rive-android:4.3.1'
   implementation "androidx.startup:startup-runtime:1.1.0"
   implementation 'com.android.volley:volley:1.2.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -135,7 +135,7 @@ dependencies {
   implementation 'androidx.core:core-ktx:1.3.2'
   implementation 'androidx.appcompat:appcompat:1.2.0'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
-  implementation 'app.rive:rive-android:4.2.7'
+  implementation 'app.rive:rive-android:4.3.0'
   implementation "androidx.startup:startup-runtime:1.1.0"
   implementation 'com.android.volley:volley:1.2.0'
 }

--- a/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
@@ -1,6 +1,7 @@
 package com.rivereactnative
 
 import android.widget.FrameLayout
+import android.util.Log
 import app.rive.runtime.kotlin.PointerEvents
 import app.rive.runtime.kotlin.RiveAnimationView
 import app.rive.runtime.kotlin.RiveArtboardRenderer
@@ -52,74 +53,100 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   }
 
   init {
+    Log.d("XYZ", "INITIALIZING $isAttachedToWindow")
     val listener = object : RiveArtboardRenderer.Listener {
       override fun notifyLoop(animation: PlayableInstance) {
-        if (animation is LinearAnimationInstance) {
-          onLoopEnd(animation.name, RNLoopMode.mapToRNLoopMode(animation.loop))
-        } else {
-          throw IllegalArgumentException("Only animation can be passed as an argument")
+        if (riveAnimationView.isAttachedToWindow) {
+          if (animation is LinearAnimationInstance) {
+            onLoopEnd(animation.name, RNLoopMode.mapToRNLoopMode(animation.loop))
+          } else {
+            throw IllegalArgumentException("Only animation can be passed as an argument")
+          }
         }
       }
 
       override fun notifyPause(animation: PlayableInstance) {
-        if (animation is LinearAnimationInstance) {
-          onPause(animation.name)
-        }
-        if (animation is StateMachineInstance) {
-          onPause(animation.name, true)
+        if (riveAnimationView.isAttachedToWindow) {
+          if (animation is LinearAnimationInstance) {
+            onPause(animation.name)
+          }
+          if (animation is StateMachineInstance) {
+            onPause(animation.name, true)
+          }
         }
       }
 
       override fun notifyPlay(animation: PlayableInstance) {
-        if (animation is LinearAnimationInstance) {
-          onPlay(animation.name)
-        }
-        if (animation is StateMachineInstance) {
-          onPlay(animation.name, true)
+        if (riveAnimationView.isAttachedToWindow) {
+          if (animation is LinearAnimationInstance) {
+            onPlay(animation.name)
+          }
+          if (animation is StateMachineInstance) {
+            onPlay(animation.name, true)
+          }
         }
       }
 
       override fun notifyStateChanged(stateMachineName: String, stateName: String) {
-        onStateChanged(stateMachineName, stateName)
+        if (riveAnimationView.isAttachedToWindow) {
+          onStateChanged(stateMachineName, stateName)
+        }
       }
 
       override fun notifyStop(animation: PlayableInstance) {
-        if (animation is LinearAnimationInstance) {
-          onStop(animation.name)
-        }
-        if (animation is StateMachineInstance) {
-          onStop(animation.name, true)
+        if (riveAnimationView.isAttachedToWindow) {
+          if (animation is LinearAnimationInstance) {
+            onStop(animation.name)
+          }
+          if (animation is StateMachineInstance) {
+            onStop(animation.name, true)
+          }
         }
       }
 
     }
     riveAnimationView.registerListener(listener)
+    riveAnimationView.autoplay = false
     autoplay = false
     addView(riveAnimationView)
+    Log.d("XYZ", "init - riveAnimationView added to view $isAttached")
   }
 
-  override fun onAttachedToWindow() {
-    // RiveReactNativeView may attach multiple times for any reason, so using
-    // a flag here isAttached to determine when it was initially attached to
-    // only addView once
-    if (childCount == 0 && isAttached == false) {
-      addView(riveAnimationView)
-      update()
-      isAttached = true
-    }
-    super.onAttachedToWindow()
-  }
+//   override fun onAttachedToWindow() {
+//     // RiveReactNativeView may attach multiple times for any reason, so using
+//     // a flag here isAttached to determine when it was initially attached to
+//     // only addView once
+// //    Log.d("XYZ", "onAttachedToWindow (beforeCheck) - isAttached? $isAttachedToWindow, childCount, $childCount ${riveAnimationView.renderer.artboardName}")
+//     if (childCount == 0 && isAttached == false) {
+// //      this.riveAnimationView = RiveAnimationView(context)
+// //      addView(riveAnimationView)
+//       Log.d("XYZ", "onAttachedToWindow (after add view) - isAttached? $isAttachedToWindow, childCount, $childCount  ${riveAnimationView.renderer.artboardName}")
+// //      update()
+//       isAttached = true
+//     }
+//     super.onAttachedToWindow()
+//   }
+////
+////
 
+//  override fun onAttachedToWindow() {
+//    Log.d("XYZ", "onAttachedToWindow () - isAttached? $isAttached, childCount, $childCount ${riveAnimationView.renderer.artboardName}")
+//    addView(riveAnimationView)
+//    super.onAttachedToWindow()
+//  }
 
-  override fun onDetachedFromWindow() {
-    // Starting in Rive Android 4.0+, we need to coordinate removing this view with
-    // the underlying RiveAnimationView when resources are cleaned up
-    removeView(riveAnimationView)
-    super.onDetachedFromWindow();
-  }
+//   override fun onDetachedFromWindow() {
+//     // Starting in Rive Android 4.0+, we need to coordinate removing this view with
+//     // the underlying RiveAnimationView when resources are cleaned up
+//     Log.d("XYZ", "onDetachedFromWindow (before remove view) - isAttached? $isAttached, childCount, $childCount ${riveAnimationView.renderer.artboardName}")
+// //    removeView(riveAnimationView)
+//     super.onDetachedFromWindow();
+//   }
+
   fun onPlay(animationName: String, isStateMachine: Boolean = false) {
     val reactContext = context as ReactContext
 
+    Log.d("XYZ", "onPlay - isStateMachine? $isStateMachine $animationName")
     val data = Arguments.createMap()
     data.putString("animationName", animationName)
     data.putBoolean("isStateMachine", isStateMachine)
@@ -130,6 +157,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   fun onPause(animationName: String, isStateMachine: Boolean = false) {
     val reactContext = context as ReactContext
 
+    Log.d("XYZ", "onPause - isStateMachine? $isStateMachine $animationName")
     val data = Arguments.createMap()
     data.putString("animationName", animationName)
     data.putBoolean("isStateMachine", isStateMachine)
@@ -140,6 +168,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   fun onStop(animationName: String, isStateMachine: Boolean = false) {
     val reactContext = context as ReactContext
 
+    Log.d("XYZ", "onStop - hit")
     val data = Arguments.createMap()
     data.putString("animationName", animationName)
     data.putBoolean("isStateMachine", isStateMachine)
@@ -159,6 +188,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
   fun onStateChanged(stateMachineName: String, stateName: String) {
     val reactContext = context as ReactContext
+    Log.d("XYZ", "onStateChanged - hit")
     val data = Arguments.createMap()
     data.putString("stateMachineName", stateMachineName)
     data.putString("stateName", stateName)
@@ -167,12 +197,15 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   }
 
   fun play(animationName: String, rnLoopMode: RNLoopMode, rnDirection: RNDirection, isStateMachine: Boolean) {
+    Log.d("XYZ", "play() - hit")
     val loop = RNLoopMode.mapToRiveLoop(rnLoopMode)
     val direction = RNDirection.mapToRiveDirection(rnDirection)
     if (animationName.isEmpty()) {
+      Log.d("XYZ", "play() - no animationName, bout to play")
       riveAnimationView.play(loop, direction) // intentionally we skipped areStateMachines argument to keep same behaviour as it is in the native sdk
     } else {
       try {
+        Log.d("XYZ", "play() - animationName $animationName, bout to play, isStateMachine, $isStateMachine")
         riveAnimationView.play(animationName, loop, direction, isStateMachine)
       } catch (ex: RiveException) {
         handleRiveException(ex)
@@ -190,6 +223,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
   fun stop() {
     try {
+      Log.d("XYZ", "stop() hit")
       riveAnimationView.stop()
     } catch (ex: RiveException) {
       handleRiveException(ex)
@@ -209,20 +243,25 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   }
 
   fun touchBegan(x: Float, y: Float) {
+    Log.d("XYZ", "TOUCH BEGAN")
     riveAnimationView.renderer.pointerEvent(PointerEvents.POINTER_DOWN, x, y)
   }
 
   fun touchEnded(x: Float, y: Float) {
+    Log.d("XYZ", "TOUCH ENDED")
     riveAnimationView.renderer.pointerEvent(PointerEvents.POINTER_UP, x, y)
   }
 
   fun update() {
+    Log.d("XYZ", "update() called!! isAttached? $isAttachedToWindow")
     reloadIfNeeded()
   }
 
   fun setResourceName(resourceName: String?) {
     resourceName?.let {
+      Log.d("XYZ", "setResourceName - $resourceName, isAttached? $isAttachedToWindow")
       resId = resources.getIdentifier(resourceName, "raw", context.packageName)
+      Log.d("XYZ", "setResourceName - resId, $resId")
       if (resId == 0) {
         resId = -1
       }
@@ -257,6 +296,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
 
   private fun resetRiveResource() {
+    Log.d("XYZ", "resetRiveResource was called?????")
     url?.let {
       if (resId == -1) {
         setUrlRiveResource(it, false)
@@ -287,6 +327,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
   private fun reloadIfNeeded() {
     if (shouldBeReloaded) {
+      Log.d("XYZ", "reloadIfNeeded should be reloaded? $shouldBeReloaded")
       url?.let {
         if (resId == -1) {
           setUrlRiveResource(it)
@@ -296,15 +337,20 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
       } ?: run {
         if (resId != -1) {
           try {
+            Log.d("XYZ", "should be reloaded? $isAttachedToWindow ${riveAnimationView.isAttachedToWindow} ${riveAnimationView.renderer.artboardName}")
             riveAnimationView.setRiveResource(
               resId,
               fit = this.fit,
               alignment = this.alignment,
-              autoplay = autoplay,
+              autoplay = this.autoplay,
               stateMachineName = this.stateMachineName,
               animationName = this.animationName,
               artboardName = this.artboardName
             )
+//            riveAnimationView.play("avatar", Loop.AUTO, Direction.AUTO, true)
+//            removeView(riveAnimationView)
+//            addView(riveAnimationView)
+            Log.d("XYZ", "after setting rive resource ${this.fit} ${this.alignment} ${this.autoplay} ${this.stateMachineName} ${this.animationName} ${this.artboardName}")
             url = null
           } catch (ex: RiveException) {
             handleRiveException(ex)
@@ -351,6 +397,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   fun setArtboardName(artboardName: String) {
     try {
       this.artboardName = artboardName
+      Log.d("XYZ", "setArtboardName $artboardName, isAttached? $isAttachedToWindow")
       riveAnimationView.artboardName = artboardName // it causes reloading
     } catch (ex: RiveException) {
       handleRiveException(ex)
@@ -359,14 +406,19 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
   fun setAnimationName(animationName: String) {
     this.animationName = animationName
-    riveAnimationView.renderer.animationName = animationName
+//    riveAnimationView.renderer.animationName = animationName
     shouldBeReloaded = true
   }
 
   fun setStateMachineName(stateMachineName: String) {
-    this.stateMachineName = stateMachineName
-    riveAnimationView.renderer.stateMachineName = stateMachineName
-    shouldBeReloaded = true
+    try {
+      this.stateMachineName = stateMachineName
+      Log.d("XYZ", "setStateMachine $stateMachineName, isAttached? $isAttachedToWindow")
+      // riveAnimationView.renderer.stateMachineName = stateMachineName
+      shouldBeReloaded = true
+    } catch (ex: RiveException) {
+      handleRiveException(ex)
+    }
   }
 
   fun setIsUserHandlingErrors(isUserHandlingErrors: Boolean) {

--- a/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
@@ -37,8 +37,6 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   private var exceptionManager: ExceptionsManagerModule? = null
   private var isUserHandlingErrors = false
 
-  private var isAttached = false;
-
   enum class Events(private val mName: String) {
     PLAY("onPlay"),
     PAUSE("onPause"),
@@ -53,54 +51,43 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   }
 
   init {
-    Log.d("XYZ", "INITIALIZING $isAttachedToWindow")
     val listener = object : RiveArtboardRenderer.Listener {
       override fun notifyLoop(animation: PlayableInstance) {
-        if (riveAnimationView.isAttachedToWindow) {
-          if (animation is LinearAnimationInstance) {
-            onLoopEnd(animation.name, RNLoopMode.mapToRNLoopMode(animation.loop))
-          } else {
-            throw IllegalArgumentException("Only animation can be passed as an argument")
-          }
+        if (animation is LinearAnimationInstance) {
+          onLoopEnd(animation.name, RNLoopMode.mapToRNLoopMode(animation.loop))
+        } else {
+          throw IllegalArgumentException("Only animation can be passed as an argument")
         }
       }
 
       override fun notifyPause(animation: PlayableInstance) {
-        if (riveAnimationView.isAttachedToWindow) {
-          if (animation is LinearAnimationInstance) {
-            onPause(animation.name)
-          }
-          if (animation is StateMachineInstance) {
-            onPause(animation.name, true)
-          }
+        if (animation is LinearAnimationInstance) {
+          onPause(animation.name)
+        }
+        if (animation is StateMachineInstance) {
+          onPause(animation.name, true)
         }
       }
 
       override fun notifyPlay(animation: PlayableInstance) {
-        if (riveAnimationView.isAttachedToWindow) {
-          if (animation is LinearAnimationInstance) {
-            onPlay(animation.name)
-          }
-          if (animation is StateMachineInstance) {
-            onPlay(animation.name, true)
-          }
+        if (animation is LinearAnimationInstance) {
+          onPlay(animation.name)
+        }
+        if (animation is StateMachineInstance) {
+          onPlay(animation.name, true)
         }
       }
 
       override fun notifyStateChanged(stateMachineName: String, stateName: String) {
-        if (riveAnimationView.isAttachedToWindow) {
-          onStateChanged(stateMachineName, stateName)
-        }
+        onStateChanged(stateMachineName, stateName)
       }
 
       override fun notifyStop(animation: PlayableInstance) {
-        if (riveAnimationView.isAttachedToWindow) {
-          if (animation is LinearAnimationInstance) {
-            onStop(animation.name)
-          }
-          if (animation is StateMachineInstance) {
-            onStop(animation.name, true)
-          }
+        if (animation is LinearAnimationInstance) {
+          onStop(animation.name)
+        }
+        if (animation is StateMachineInstance) {
+          onStop(animation.name, true)
         }
       }
 
@@ -109,44 +96,11 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
     riveAnimationView.autoplay = false
     autoplay = false
     addView(riveAnimationView)
-    Log.d("XYZ", "init - riveAnimationView added to view $isAttached")
   }
-
-//   override fun onAttachedToWindow() {
-//     // RiveReactNativeView may attach multiple times for any reason, so using
-//     // a flag here isAttached to determine when it was initially attached to
-//     // only addView once
-// //    Log.d("XYZ", "onAttachedToWindow (beforeCheck) - isAttached? $isAttachedToWindow, childCount, $childCount ${riveAnimationView.renderer.artboardName}")
-//     if (childCount == 0 && isAttached == false) {
-// //      this.riveAnimationView = RiveAnimationView(context)
-// //      addView(riveAnimationView)
-//       Log.d("XYZ", "onAttachedToWindow (after add view) - isAttached? $isAttachedToWindow, childCount, $childCount  ${riveAnimationView.renderer.artboardName}")
-// //      update()
-//       isAttached = true
-//     }
-//     super.onAttachedToWindow()
-//   }
-////
-////
-
-//  override fun onAttachedToWindow() {
-//    Log.d("XYZ", "onAttachedToWindow () - isAttached? $isAttached, childCount, $childCount ${riveAnimationView.renderer.artboardName}")
-//    addView(riveAnimationView)
-//    super.onAttachedToWindow()
-//  }
-
-//   override fun onDetachedFromWindow() {
-//     // Starting in Rive Android 4.0+, we need to coordinate removing this view with
-//     // the underlying RiveAnimationView when resources are cleaned up
-//     Log.d("XYZ", "onDetachedFromWindow (before remove view) - isAttached? $isAttached, childCount, $childCount ${riveAnimationView.renderer.artboardName}")
-// //    removeView(riveAnimationView)
-//     super.onDetachedFromWindow();
-//   }
 
   fun onPlay(animationName: String, isStateMachine: Boolean = false) {
     val reactContext = context as ReactContext
 
-    Log.d("XYZ", "onPlay - isStateMachine? $isStateMachine $animationName")
     val data = Arguments.createMap()
     data.putString("animationName", animationName)
     data.putBoolean("isStateMachine", isStateMachine)
@@ -157,7 +111,6 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   fun onPause(animationName: String, isStateMachine: Boolean = false) {
     val reactContext = context as ReactContext
 
-    Log.d("XYZ", "onPause - isStateMachine? $isStateMachine $animationName")
     val data = Arguments.createMap()
     data.putString("animationName", animationName)
     data.putBoolean("isStateMachine", isStateMachine)
@@ -168,7 +121,6 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   fun onStop(animationName: String, isStateMachine: Boolean = false) {
     val reactContext = context as ReactContext
 
-    Log.d("XYZ", "onStop - hit")
     val data = Arguments.createMap()
     data.putString("animationName", animationName)
     data.putBoolean("isStateMachine", isStateMachine)
@@ -188,7 +140,6 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
   fun onStateChanged(stateMachineName: String, stateName: String) {
     val reactContext = context as ReactContext
-    Log.d("XYZ", "onStateChanged - hit")
     val data = Arguments.createMap()
     data.putString("stateMachineName", stateMachineName)
     data.putString("stateName", stateName)
@@ -197,15 +148,12 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   }
 
   fun play(animationName: String, rnLoopMode: RNLoopMode, rnDirection: RNDirection, isStateMachine: Boolean) {
-    Log.d("XYZ", "play() - hit")
     val loop = RNLoopMode.mapToRiveLoop(rnLoopMode)
     val direction = RNDirection.mapToRiveDirection(rnDirection)
     if (animationName.isEmpty()) {
-      Log.d("XYZ", "play() - no animationName, bout to play")
       riveAnimationView.play(loop, direction) // intentionally we skipped areStateMachines argument to keep same behaviour as it is in the native sdk
     } else {
       try {
-        Log.d("XYZ", "play() - animationName $animationName, bout to play, isStateMachine, $isStateMachine")
         riveAnimationView.play(animationName, loop, direction, isStateMachine)
       } catch (ex: RiveException) {
         handleRiveException(ex)
@@ -223,7 +171,6 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
   fun stop() {
     try {
-      Log.d("XYZ", "stop() hit")
       riveAnimationView.stop()
     } catch (ex: RiveException) {
       handleRiveException(ex)
@@ -233,7 +180,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   fun reset() {
     url?.let {
       if (resId == -1) {
-        riveAnimationView.renderer.reset()
+        riveAnimationView.artboardRenderer?.reset()
       }
     } ?: run {
       if (resId != -1) {
@@ -243,25 +190,20 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   }
 
   fun touchBegan(x: Float, y: Float) {
-    Log.d("XYZ", "TOUCH BEGAN")
-    riveAnimationView.renderer.pointerEvent(PointerEvents.POINTER_DOWN, x, y)
+    riveAnimationView.artboardRenderer?.pointerEvent(PointerEvents.POINTER_DOWN, x, y)
   }
 
   fun touchEnded(x: Float, y: Float) {
-    Log.d("XYZ", "TOUCH ENDED")
-    riveAnimationView.renderer.pointerEvent(PointerEvents.POINTER_UP, x, y)
+    riveAnimationView.artboardRenderer?.pointerEvent(PointerEvents.POINTER_UP, x, y)
   }
 
   fun update() {
-    Log.d("XYZ", "update() called!! isAttached? $isAttachedToWindow")
     reloadIfNeeded()
   }
 
   fun setResourceName(resourceName: String?) {
     resourceName?.let {
-      Log.d("XYZ", "setResourceName - $resourceName, isAttached? $isAttachedToWindow")
       resId = resources.getIdentifier(resourceName, "raw", context.packageName)
-      Log.d("XYZ", "setResourceName - resId, $resId")
       if (resId == 0) {
         resId = -1
       }
@@ -296,7 +238,6 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
 
   private fun resetRiveResource() {
-    Log.d("XYZ", "resetRiveResource was called?????")
     url?.let {
       if (resId == -1) {
         setUrlRiveResource(it, false)
@@ -327,7 +268,6 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
   private fun reloadIfNeeded() {
     if (shouldBeReloaded) {
-      Log.d("XYZ", "reloadIfNeeded should be reloaded? $shouldBeReloaded")
       url?.let {
         if (resId == -1) {
           setUrlRiveResource(it)
@@ -337,7 +277,6 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
       } ?: run {
         if (resId != -1) {
           try {
-            Log.d("XYZ", "should be reloaded? $isAttachedToWindow ${riveAnimationView.isAttachedToWindow} ${riveAnimationView.renderer.artboardName}")
             riveAnimationView.setRiveResource(
               resId,
               fit = this.fit,
@@ -347,10 +286,6 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
               animationName = this.animationName,
               artboardName = this.artboardName
             )
-//            riveAnimationView.play("avatar", Loop.AUTO, Direction.AUTO, true)
-//            removeView(riveAnimationView)
-//            addView(riveAnimationView)
-            Log.d("XYZ", "after setting rive resource ${this.fit} ${this.alignment} ${this.autoplay} ${this.stateMachineName} ${this.animationName} ${this.artboardName}")
             url = null
           } catch (ex: RiveException) {
             handleRiveException(ex)
@@ -397,7 +332,6 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   fun setArtboardName(artboardName: String) {
     try {
       this.artboardName = artboardName
-      Log.d("XYZ", "setArtboardName $artboardName, isAttached? $isAttachedToWindow")
       riveAnimationView.artboardName = artboardName // it causes reloading
     } catch (ex: RiveException) {
       handleRiveException(ex)
@@ -406,15 +340,14 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
   fun setAnimationName(animationName: String) {
     this.animationName = animationName
-//    riveAnimationView.renderer.animationName = animationName
+    riveAnimationView.artboardRenderer?.animationName = animationName
     shouldBeReloaded = true
   }
 
   fun setStateMachineName(stateMachineName: String) {
     try {
       this.stateMachineName = stateMachineName
-      Log.d("XYZ", "setStateMachine $stateMachineName, isAttached? $isAttachedToWindow")
-      // riveAnimationView.renderer.stateMachineName = stateMachineName
+      riveAnimationView.artboardRenderer?.stateMachineName = stateMachineName
       shouldBeReloaded = true
     } catch (ex: RiveException) {
       handleRiveException(ex)

--- a/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
@@ -1,7 +1,6 @@
 package com.rivereactnative
 
 import android.widget.FrameLayout
-import android.util.Log
 import app.rive.runtime.kotlin.PointerEvents
 import app.rive.runtime.kotlin.RiveAnimationView
 import app.rive.runtime.kotlin.RiveArtboardRenderer
@@ -93,7 +92,6 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
     }
     riveAnimationView.registerListener(listener)
-    riveAnimationView.autoplay = false
     autoplay = false
     addView(riveAnimationView)
   }
@@ -345,13 +343,9 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   }
 
   fun setStateMachineName(stateMachineName: String) {
-    try {
       this.stateMachineName = stateMachineName
       riveAnimationView.artboardRenderer?.stateMachineName = stateMachineName
       shouldBeReloaded = true
-    } catch (ex: RiveException) {
-      handleRiveException(ex)
-    }
   }
 
   fun setIsUserHandlingErrors(isUserHandlingErrors: Boolean) {

--- a/android/src/main/java/com/rivereactnative/RiveReactNativeViewManager.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeViewManager.kt
@@ -1,6 +1,5 @@
 package com.rivereactnative
 
-import android.view.MotionEvent
 import android.util.Log
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.MapBuilder
@@ -20,7 +19,6 @@ class RiveReactNativeViewManager : SimpleViewManager<RiveReactNativeView>() {
   override fun getName() = "RiveReactNativeView"
 
   override fun receiveCommand(view: RiveReactNativeView, commandId: String, args: ReadableArray?) {
-    Log.d("XYZ", "COMMAND -> $commandId ${view.isAttachedToWindow}")
     when (commandId) {
       // Playback Controls
 
@@ -107,7 +105,6 @@ class RiveReactNativeViewManager : SimpleViewManager<RiveReactNativeView>() {
 
   override fun onAfterUpdateTransaction(view: RiveReactNativeView) {
     super.onAfterUpdateTransaction(view)
-    Log.d("XYZ", "Bout to update ${view.isAttachedToWindow}")
     view.update()
   }
 

--- a/android/src/main/java/com/rivereactnative/RiveReactNativeViewManager.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeViewManager.kt
@@ -1,6 +1,7 @@
 package com.rivereactnative
 
 import android.view.MotionEvent
+import android.util.Log
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.SimpleViewManager
@@ -19,6 +20,7 @@ class RiveReactNativeViewManager : SimpleViewManager<RiveReactNativeView>() {
   override fun getName() = "RiveReactNativeView"
 
   override fun receiveCommand(view: RiveReactNativeView, commandId: String, args: ReadableArray?) {
+    Log.d("XYZ", "COMMAND -> $commandId ${view.isAttachedToWindow}")
     when (commandId) {
       // Playback Controls
 
@@ -101,6 +103,12 @@ class RiveReactNativeViewManager : SimpleViewManager<RiveReactNativeView>() {
 
   override fun createViewInstance(reactContext: ThemedReactContext): RiveReactNativeView {
     return RiveReactNativeView(reactContext)
+  }
+
+  override fun onAfterUpdateTransaction(view: RiveReactNativeView) {
+    super.onAfterUpdateTransaction(view)
+    Log.d("XYZ", "Bout to update ${view.isAttachedToWindow}")
+    view.update()
   }
 
   @ReactProp(name = "resourceName")

--- a/example/android/app/src/main/java/com/example/rivereactnative/MainActivity.java
+++ b/example/android/app/src/main/java/com/example/rivereactnative/MainActivity.java
@@ -1,6 +1,7 @@
 package com.example.rivereactnative;
 
 import com.facebook.react.ReactActivity;
+import android.os.Bundle;
 
 public class MainActivity extends ReactActivity {
 
@@ -11,5 +12,10 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "RiveReactNativeExample";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
   }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -371,7 +371,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.18.2):
+  - RNScreens (3.20.0):
     - React-Core
     - React-RCTImage
   - RNVectorIcons (8.1.0):
@@ -583,7 +583,7 @@ SPEC CHECKSUMS:
   RNCPicker: 0991c56da7815c0cf946d6f63cf920b25296e5f6
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: 7c664a74689972eff8e726535824233596f5f158
-  RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
+  RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
   Yoga: 1561f557b0c2b6047a91f7619f666134e2288916
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/example/package.json
+++ b/example/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@react-native-masked-view/masked-view": "^0.2.8",
     "@react-native-picker/picker": "^1.16.0",
-    "@react-navigation/native": "^6.0.13",
-    "@react-navigation/stack": "^6.3.4",
+    "@react-navigation/native": "6.x",
+    "@react-navigation/stack": "6.x",
     "react": "17.0.2",
     "react-native": "0.65.0",
     "react-native-gesture-handler": "^1.10.3",
@@ -20,7 +20,7 @@
     "react-native-paper": "^4.8.1",
     "react-native-reanimated": "^2.1.0",
     "react-native-safe-area-context": "^3.2.0",
-    "react-native-screens": "^3.2.0",
+    "react-native-screens": "^3.20.0",
     "react-native-vector-icons": "^8.1.0"
   },
   "devDependencies": {

--- a/example/src/Simple.tsx
+++ b/example/src/Simple.tsx
@@ -12,8 +12,7 @@ export default function Simple() {
           style={styles.animation}
           artboardName={'Avatar 3'}
           autoplay={true}
-          // animationName="idlePreview"
-          stateMachineName="avatar3"
+          animationName="idlePreview"
           resourceName={'avatars'}
         />
       </ScrollView>

--- a/example/src/Simple.tsx
+++ b/example/src/Simple.tsx
@@ -11,7 +11,9 @@ export default function Simple() {
           alignment={Alignment.Center}
           style={styles.animation}
           artboardName={'Avatar 3'}
-          animationName="idlePreview"
+          autoplay={true}
+          // animationName="idlePreview"
+          stateMachineName="avatar3"
           resourceName={'avatars'}
         />
       </ScrollView>

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -966,46 +966,46 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-1.0.0.tgz#05bb0031533598f9458cf65a502b8df0eecae780"
   integrity sha512-0jbp4RxjYopTsIdLl+/Fy2TiwVYHy4mgeu07DG4b/LyM0OS/+lPP5c9sbnt/AMlnF6qz2JRZpPpGw1eMNS6A4w==
 
-"@react-navigation/core@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-6.4.0.tgz#c44d33a8d8ef010a102c7f831fc8add772678509"
-  integrity sha512-tpc0Ak/DiHfU3LlYaRmIY7vI4sM/Ru0xCet6runLUh9aABf4wiLgxyFJ5BtoWq6xFF8ymYEA/KWtDhetQ24YiA==
+"@react-navigation/core@^6.4.8":
+  version "6.4.8"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-6.4.8.tgz#a18e106d3c59cdcfc4ce53f7344e219ed35c88ed"
+  integrity sha512-klZ9Mcf/P2j+5cHMoGyIeurEzyBM2Uq9+NoSFrF6sdV5iCWHLFhrCXuhbBiQ5wVLCKf4lavlkd/DDs47PXs9RQ==
   dependencies:
-    "@react-navigation/routers" "^6.1.3"
+    "@react-navigation/routers" "^6.1.8"
     escape-string-regexp "^4.0.0"
     nanoid "^3.1.23"
-    query-string "^7.0.0"
+    query-string "^7.1.3"
     react-is "^16.13.0"
     use-latest-callback "^0.1.5"
 
-"@react-navigation/elements@^1.3.6":
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.6.tgz#fa700318528db93f05144b1be4b691b9c1dd1abe"
-  integrity sha512-pNJ8R9JMga6SXOw6wGVN0tjmE6vegwPmJBL45SEMX2fqTfAk2ykDnlJHodRpHpAgsv0DaI8qX76z3A+aqKSU0w==
+"@react-navigation/elements@^1.3.17":
+  version "1.3.17"
+  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.17.tgz#9cb95765940f2841916fc71686598c22a3e4067e"
+  integrity sha512-sui8AzHm6TxeEvWT/NEXlz3egYvCUog4tlXA4Xlb2Vxvy3purVXDq/XsM56lJl344U5Aj/jDzkVanOTMWyk4UA==
 
-"@react-navigation/native@^6.0.13":
-  version "6.0.13"
-  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.0.13.tgz#ec504120e193ea6a7f24ffa765a1338be5a3160a"
-  integrity sha512-CwaJcAGbhv3p3ECablxBkw8QBCGDWXqVRwQ4QbelajNW623m3sNTC9dOF6kjp8au6Rg9B5e0KmeuY0xWbPk79A==
+"@react-navigation/native@6.x":
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.1.6.tgz#84ff5cf85b91f660470fa9407c06c8ee393d5792"
+  integrity sha512-14PmSy4JR8HHEk04QkxQ0ZLuqtiQfb4BV9kkMXD2/jI4TZ+yc43OnO6fQ2o9wm+Bq8pY3DxyerC2AjNUz+oH7Q==
   dependencies:
-    "@react-navigation/core" "^6.4.0"
+    "@react-navigation/core" "^6.4.8"
     escape-string-regexp "^4.0.0"
     fast-deep-equal "^3.1.3"
     nanoid "^3.1.23"
 
-"@react-navigation/routers@^6.1.3":
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-6.1.3.tgz#1df51959e9a67c44367462e8b929b7360a5d2555"
-  integrity sha512-idJotMEzHc3haWsCh7EvnnZMKxvaS4YF/x2UyFBkNFiEFUaEo/1ioQU6qqmVLspdEv4bI/dLm97hQo7qD8Yl7Q==
+"@react-navigation/routers@^6.1.8":
+  version "6.1.8"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-6.1.8.tgz#ae56b2678dbb5abca5bd7c95d6a8d1abc767cba2"
+  integrity sha512-CEge+ZLhb1HBrSvv4RwOol7EKLW1QoqVIQlE9TN5MpxS/+VoQvP+cLbuz0Op53/iJfYhtXRFd1ZAd3RTRqto9w==
   dependencies:
     nanoid "^3.1.23"
 
-"@react-navigation/stack@^6.3.4":
-  version "6.3.4"
-  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-6.3.4.tgz#c3b7a479aea609c0de609f91be7b2539dbae37c2"
-  integrity sha512-f4vQcbaDPSFHF1i6CnEYbA0Bnk5jRGMoCIs2/Tq0HwsUI62Mui1q5vvIlRDIi5QomJoHzhfTBp9IzMQ/sUQJlg==
+"@react-navigation/stack@6.x":
+  version "6.3.16"
+  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-6.3.16.tgz#cf94e3c8c1587455515743e91d328beef722e0ab"
+  integrity sha512-KTOn9cNuZ6p154Htbl2DiR95Wl+c7niLPRiGs7gjOkyVDGiaGQF9ODNQTYBDE1OxZGHe/EyYc6T2CbmiItLWDg==
   dependencies:
-    "@react-navigation/elements" "^1.3.6"
+    "@react-navigation/elements" "^1.3.17"
     color "^4.2.3"
     warn-once "^0.1.0"
 
@@ -1776,6 +1776,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==
+
+decode-uri-component@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 deepmerge@^3.2.0:
   version "3.3.0"
@@ -3573,12 +3578,12 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-query-string@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
-  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
+query-string@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
+  integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
   dependencies:
-    decode-uri-component "^0.2.0"
+    decode-uri-component "^0.2.2"
     filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
@@ -3671,10 +3676,10 @@ react-native-safe-area-context@^3.2.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.4.1.tgz#c967a52903d55fe010b2428e5368b42f1debc0a7"
   integrity sha512-xfpVd0CiZR7oBhuwJ2HcZMehg5bjha1Ohu1XHpcT+9ykula0TgovH2BNU0R5Krzf/jBR1LMjR6VabxdlUjqxcA==
 
-react-native-screens@^3.2.0:
-  version "3.18.2"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.18.2.tgz#d7ab2d145258d3db9fa630fa5379dc4474117866"
-  integrity sha512-ANUEuvMUlsYJ1QKukEhzhfrvOUO9BVH9Nzg+6eWxpn3cfD/O83yPBOF8Mx6x5H/2+sMy+VS5x/chWOOo/U7QJw==
+react-native-screens@^3.20.0:
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.20.0.tgz#4d154177395e5541387d9a05bc2e12e54d2fb5b1"
+  integrity sha512-joWUKWAVHxymP3mL9gYApFHAsbd9L6ZcmpoZa6Sl3W/82bvvNVMqcfP7MeNqVCg73qZ8yL4fW+J/syusHleUgg==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rive-react-native",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Rive React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Previously with 4.0.0 release of React Native, we had an issue of simply displaying Rive on Android. With some recent changes in the underlying Android runtime, as well as reverting back to using `onAfterUpdateTransaction` in the RiveReactNativeViewManager rather than coordinating attach/detach lifecycles in the binding RiveReactNativeView layer, this should address simply displaying Rive for Android.