### PR TITLE
fix: controller refcount out of sync with view

### DIFF
--- a/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
@@ -115,6 +115,12 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   }
 
   @OptIn(ControllerStateManagement::class)
+  fun dispose() {
+    removeView(riveAnimationView)
+    controllerState?.dispose();
+  }
+
+  @OptIn(ControllerStateManagement::class)
   override fun onAttachedToWindow() {
     // The below solves: https://github.com/rive-app/rive-react-native/issues/198
     // When the view is returned to, we reuse the view's resources.

--- a/android/src/main/java/com/rivereactnative/RiveReactNativeViewManager.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeViewManager.kt
@@ -1,6 +1,5 @@
 package com.rivereactnative
 
-import android.util.Log
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.SimpleViewManager
@@ -113,6 +112,11 @@ class RiveReactNativeViewManager : SimpleViewManager<RiveReactNativeView>() {
 
   override fun createViewInstance(reactContext: ThemedReactContext): RiveReactNativeView {
     return RiveReactNativeView(reactContext)
+  }
+
+  override fun onDropViewInstance(view: RiveReactNativeView) {
+    view.dispose();
+    super.onDropViewInstance(view)
   }
 
   override fun onAfterUpdateTransaction(view: RiveReactNativeView) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rive-react-native",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Rive React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Fixes: https://github.com/rive-app/rive-react-native/issues/198

This may need to be revisited on native Android, as there could be some discussion on making the current controller refcount more decoupled to how it is currently handled. But I could not replicate the issue natively, and it could be that ReactNative is managing the view is unique and not something that would cause issues in native use.

It may also be that we change the view creation logic in ReactNative in the future, so I'm opting in for a patch that ensures RN behaves sensibly with regards to the controller ref count on view navigation. Also adding a lot of code comments + considerations/alternatives.