### PR TITLE
fix: "Exception thrown while executing UI block: -[rive_react_native.RiveReactNativeView setOnClick:]: unrecognized selector sent to instance"

### DIFF
--- a/ios/RiveReactNative-Bridging-Header.h
+++ b/ios/RiveReactNative-Bridging-Header.h
@@ -4,5 +4,6 @@
 #import "React/RCTUIManager.h"
 #import <React/RCTUtils.h>
 #import "React/RCTExceptionsManager.h"
+#import <React/RCTView.h>
 
 

--- a/ios/RiveReactNativeView.swift
+++ b/ios/RiveReactNativeView.swift
@@ -1,7 +1,7 @@
 import UIKit
 import RiveRuntime
 
-class RiveReactNativeView: UIView, RivePlayerDelegate, RiveStateMachineDelegate {
+class RiveReactNativeView: RCTView, RivePlayerDelegate, RiveStateMachineDelegate {
     // MARK: RiveReactNativeView Properties
     private var resourceFromBundle = true
     private var requiresLocalResourceReconfigure = false


### PR DESCRIPTION
RE: https://github.com/rive-app/rive-react-native/issues/214

When upgrading to React Native 0.73, it seems views receive experimental and unused props from React Native. By deriving the custom view `RiveReactNativeView` from `RCTView` from React Native instead of `UIView`, stubs for these props are provided for free. 

I have checked this makes the specific issue I'm trying to fix go away and seems to run just fine, but please help me to understand if there may be unintended consequences or a better approach that might be more suitable.

Thanks in advance!