### PR TITLE
feat: support custom onPress as well as prop to disable default behaviour for clicking on animation

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -487,7 +487,7 @@ PODS:
     - React-jsi (= 0.72.7)
     - React-logger (= 0.72.7)
     - React-perflogger (= 0.72.7)
-  - rive-react-native (6.1.1):
+  - rive-react-native (6.2.0):
     - React-Core
     - RiveRuntime (= 5.5.1)
   - RiveRuntime (5.5.1)
@@ -744,7 +744,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 7649c3b46c8dee1853691ecf60146a16ae59253c
   React-utils: 56838edeaaf651220d1e53cd0b8934fb8ce68415
   ReactCommon: 5f704096ccf7733b390f59043b6fa9cc180ee4f6
-  rive-react-native: 112e318d564488e79cef71ed192f13b5768e196b
+  rive-react-native: 82eb809ebec7ab5059982dc1a2b6097c74d722ea
   RiveRuntime: b57830ff73f406f3b4022f457b16690535ca4d05
   RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
   RNCPicker: 0991c56da7815c0cf946d6f63cf920b25296e5f6

--- a/src/Rive.tsx
+++ b/src/Rive.tsx
@@ -66,6 +66,7 @@ type RiveProps = {
       message: string;
     }>
   ) => void;
+  onPress?: () => void;
   isUserHandlingErrors: boolean;
   autoplay?: boolean;
   fit: Fit;
@@ -78,6 +79,7 @@ type RiveProps = {
   url?: string;
   style?: StyleProp<ViewStyle>;
   testID?: string;
+  disableDefaultTouchHandling?: boolean;
 };
 
 const VIEW_NAME = 'RiveReactNativeView';
@@ -90,6 +92,7 @@ type Props = {
   onStateChanged?: (stateMachineName: string, stateName: string) => void;
   onRiveEventReceived?: (event: RiveGeneralEvent | RiveOpenUrlEvent) => void;
   onError?: (rnRiveError: RNRiveError) => void;
+  onPress?: () => void;
   fit?: Fit;
   style?: ViewStyle;
   testID?: string;
@@ -99,6 +102,7 @@ type Props = {
   stateMachineName?: string;
   autoplay?: boolean;
   children?: React.ReactNode;
+  disableDefaultTouchHandling?: boolean;
 } & XOR<{ resourceName: string }, { url: string }>;
 
 export const RiveViewManager = requireNativeComponent<RiveProps>(VIEW_NAME);
@@ -114,6 +118,7 @@ const RiveContainer = React.forwardRef<RiveRef, Props>(
       onStateChanged,
       onRiveEventReceived,
       onError,
+      onPress,
       style,
       autoplay = true,
       resourceName,
@@ -124,6 +129,7 @@ const RiveContainer = React.forwardRef<RiveRef, Props>(
       animationName,
       stateMachineName,
       testID,
+      disableDefaultTouchHandling = false,
     },
     ref
   ) => {
@@ -364,11 +370,14 @@ const RiveContainer = React.forwardRef<RiveRef, Props>(
         <View style={styles.children}>{children}</View>
         <TouchableWithoutFeedback
           onPressIn={(event: GestureResponderEvent) =>
+            !disableDefaultTouchHandling &&
             touchBegan(event.nativeEvent.locationX, event.nativeEvent.locationY)
           }
           onPressOut={(event: GestureResponderEvent) =>
+            !disableDefaultTouchHandling &&
             touchEnded(event.nativeEvent.locationX, event.nativeEvent.locationY)
           }
+          onPress={onPress}
         >
           <RiveViewManager
             ref={riveRef}


### PR DESCRIPTION
Adding in this PR based on a requirement we had.

Sometimes wrapping the Rive component with a TouchableOpacity or other Touchable (Other than TouchableWithoutFeedback) would not work. Because the inner TouchableWithoutFeedback is taking priority.

Therefore adding a custom onPress prop which can be called when the animation is clicked, as well as an option to disable the default handling

Our Use Case:
* Animation has an onClick trigger
* We want to trigger another side effect when animation is clicked
* We cannot use a Touchable because it does not work
* So using the new onPress to call `riveRef.current?.setInputState` to trigger the animation as well as our side effect