### PR TITLE
chore: bump iOS and Android dependencies to get latest bug fixes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion 24
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"
@@ -135,7 +135,7 @@ dependencies {
   implementation 'androidx.core:core-ktx:1.12.0'
   implementation 'androidx.appcompat:appcompat:1.6.1'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
-  implementation 'app.rive:rive-android:8.7.0'
+  implementation 'app.rive:rive-android:9.2.2'
   implementation "androidx.startup:startup-runtime:1.1.1"
   implementation 'com.android.volley:volley:1.2.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 21
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"
@@ -135,7 +135,7 @@ dependencies {
   implementation 'androidx.core:core-ktx:1.12.0'
   implementation 'androidx.appcompat:appcompat:1.6.1'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
-  implementation 'app.rive:rive-android:9.2.2'
+  implementation 'app.rive:rive-android:9.3.0'
   implementation "androidx.startup:startup-runtime:1.1.1"
   implementation 'com.android.volley:volley:1.2.0'
 }

--- a/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
@@ -5,7 +5,7 @@ import androidx.annotation.CallSuper
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import app.rive.runtime.kotlin.PointerEvents
+import app.rive.runtime.kotlin.renderers.PointerEvents
 import app.rive.runtime.kotlin.RiveAnimationView
 import app.rive.runtime.kotlin.controllers.RiveFileController
 import app.rive.runtime.kotlin.core.*
@@ -158,7 +158,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
   override fun onDetachedFromWindow() {
     if (willDispose) {
-      riveAnimationView?.dispose();
+      riveAnimationView.dispose();
     }
 
     super.onDetachedFromWindow()
@@ -301,16 +301,16 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   }
 
   fun touchBegan(x: Float, y: Float) {
-    riveAnimationView.artboardRenderer?.pointerEvent(PointerEvents.POINTER_DOWN, x, y)
+    riveAnimationView.controller.pointerEvent(PointerEvents.POINTER_DOWN, x, y)
   }
 
   fun touchEnded(x: Float, y: Float) {
-    riveAnimationView.artboardRenderer?.pointerEvent(PointerEvents.POINTER_UP, x, y)
+    riveAnimationView.controller.pointerEvent(PointerEvents.POINTER_UP, x, y)
   }
 
   fun setTextRunValue(textRunName: String, textValue: String) {
     try {
-      riveAnimationView.artboardRenderer?.activeArtboard?.textRun(textRunName)?.text = textValue;
+      riveAnimationView.controller.activeArtboard?.textRun(textRunName)?.text = textValue;
     } catch (ex: RiveException) {
       handleRiveException(ex)
     }
@@ -459,13 +459,11 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
 
   fun setAnimationName(animationName: String) {
     this.animationName = animationName
-    riveAnimationView.artboardRenderer?.animationName = animationName
     shouldBeReloaded = true
   }
 
   fun setStateMachineName(stateMachineName: String) {
       this.stateMachineName = stateMachineName
-      riveAnimationView.artboardRenderer?.stateMachineName = stateMachineName
       shouldBeReloaded = true
   }
 

--- a/android/src/main/java/com/rivereactnative/RiveReactNativeViewManager.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeViewManager.kt
@@ -23,9 +23,9 @@ class RiveReactNativeViewManager : SimpleViewManager<RiveReactNativeView>() {
 
       "play" -> {
         args?.let {
-          val animationName = it.getString(0)!!
-          val loopMode = it.getString(1)!!
-          val direction = it.getString(2)!!
+          val animationName = it.getString(0)
+          val loopMode = it.getString(1)
+          val direction = it.getString(2)
           val isStateMachine = it.getBoolean(3)
           view.run {
             val rnLoopMode = RNLoopMode.mapToRNLoopMode(loopMode)
@@ -43,8 +43,8 @@ class RiveReactNativeViewManager : SimpleViewManager<RiveReactNativeView>() {
 
       "fireState" -> {
         args?.let {
-          val stateMachineName = it.getString(0)!!
-          val inputName = it.getString(1)!!
+          val stateMachineName = it.getString(0)
+          val inputName = it.getString(1)
           view.run {
             fireState(stateMachineName, inputName)
           }
@@ -52,8 +52,8 @@ class RiveReactNativeViewManager : SimpleViewManager<RiveReactNativeView>() {
       }
       "setBooleanState" -> {
         args?.let {
-          val stateMachineName = it.getString(0)!!
-          val inputName = it.getString(1)!!
+          val stateMachineName = it.getString(0)
+          val inputName = it.getString(1)
           val value = it.getBoolean(2)
           view.run {
             setBooleanState(stateMachineName, inputName, value)
@@ -62,8 +62,8 @@ class RiveReactNativeViewManager : SimpleViewManager<RiveReactNativeView>() {
       }
       "setNumberState" -> {
         args?.let {
-          val stateMachineName = it.getString(0)!!
-          val inputName = it.getString(1)!!
+          val stateMachineName = it.getString(0)
+          val inputName = it.getString(1)
           val value = it.getDouble(2)
           view.run {
             setNumberState(stateMachineName, inputName, value.toFloat())

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "34.0.0"
-        minSdkVersion = 21
+        minSdkVersion = 24
         compileSdkVersion = 34
         targetSdkVersion = 34
         kotlinVersion = "1.8.10"

--- a/ios/utility.swift
+++ b/ios/utility.swift
@@ -26,7 +26,7 @@ func importRiveFile(from url: URL) throws ->  RiveFile {
         }
         let pointer = rawPointer.bindMemory(to: UInt8.self, capacity: bytes.count)
         
-            let riveFile = try RiveFile(bytes:pointer, byteLength: UInt64(bytes.count))
+            let riveFile = try RiveFile(bytes:pointer, byteLength: UInt64(bytes.count), loadCdn: true)
             return riveFile
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rive-react-native",
-  "version": "6.2.3",
+  "version": "6.3.0",
   "description": "Rive React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/rive-react-native.podspec
+++ b/rive-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "RiveRuntime", "5.5.1"
+  s.dependency "RiveRuntime", "5.10.0"
 end


### PR DESCRIPTION
Bumping iOS to 5.10.0 and Android 9.3.0

Notes:

- Needed to bump the minSDKVersion to 24 to resolve dexing errors when building. Its possible there were other dependency conflicts which weren't obvious, so perhaps this change isn't necessary.