### PR TITLE
chore: bump major version for iOS and Android updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rive-react-native",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "description": "Rive React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Major version bump for pulling in iOS 5.10.0 and Android 9.3.0