### PR TITLE
chore: release v7.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -135,7 +135,7 @@ dependencies {
   implementation 'androidx.core:core-ktx:1.12.0'
   implementation 'androidx.appcompat:appcompat:1.6.1'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
-  implementation 'app.rive:rive-android:9.3.0'
+  implementation 'app.rive:rive-android:9.3.1'
   implementation "androidx.startup:startup-runtime:1.1.1"
   implementation 'com.android.volley:volley:1.2.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rive-react-native",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Rive React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Bump Rive Android, with a fix for: https://github.com/rive-app/rive-android/issues/324