### PR TITLE
chore: release v7.0.4 with version bumps for ios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rive-react-native",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "Rive React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/rive-react-native.podspec
+++ b/rive-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "RiveRuntime", "5.11.3"
+  s.dependency "RiveRuntime", "5.11.5"
 end


### PR DESCRIPTION
Unavailable to install pods for rive-react-native@7.0.3. 
Pod release v5.11.3 not exists in Cocoapods repo.

Linked issues: 
- #238
- rive-app/rive-ios#311