### PR TITLE
add Android RN 0.73 Support 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,10 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
-  // namespace 'com.rivereactnative'
+  // Conditional for compatibility with AGP <4.2.
+  if (project.android.hasProperty("namespace")) {
+    namespace = "com.rivereactnative"
+  }
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {


### PR DESCRIPTION
follow https://stackoverflow.com/questions/76108428/how-do-i-fix-namespace-not-specified-error-in-android-studio

and https://github.com/getsentry/sentry-react-native/blob/main/android/build.gradle#L17C5-L20C6

which fixed Android Gradle Plugin error >= 8.x.x