### PR TITLE
chore: release 7.1.0

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -489,8 +489,8 @@ PODS:
     - React-perflogger (= 0.72.7)
   - rive-react-native (7.0.5):
     - React-Core
-    - RiveRuntime (= 5.11.6)
-  - RiveRuntime (5.11.6)
+    - RiveRuntime (= 5.12.0)
+  - RiveRuntime (5.12.0)
   - RNCMaskedView (0.2.9):
     - React-Core
   - RNCPicker (1.16.8):
@@ -744,8 +744,8 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 7649c3b46c8dee1853691ecf60146a16ae59253c
   React-utils: 56838edeaaf651220d1e53cd0b8934fb8ce68415
   ReactCommon: 5f704096ccf7733b390f59043b6fa9cc180ee4f6
-  rive-react-native: a02b3df3c24c07cd8cb0e34ef801921aa6f0859e
-  RiveRuntime: 36def428ea2cc2218680031e911e56c94092fad6
+  rive-react-native: df5727c937700a82018cf6a1ee12fbf5e4cc0296
+  RiveRuntime: 9568f984e8f8489ec1198268b09b496890d0efdc
   RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
   RNCPicker: 0991c56da7815c0cf946d6f63cf920b25296e5f6
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rive-react-native",
-  "version": "7.0.5",
+  "version": "7.1.0",
   "description": "Rive React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/rive-react-native.podspec
+++ b/rive-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "RiveRuntime", "5.11.6"
+  s.dependency "RiveRuntime", "5.12.0"
 end


### PR DESCRIPTION
- Includes a new API to set the default renderer to use for iOS and Android.
- Bumps iOS to the latest version
- Adds conditional Android namespace: https://github.com/rive-app/rive-react-native/pull/245

### Setting a default renderer
```js
export default function Main() {
  // Configure the defualt renderer to use for both iOS and Android.
  // For more information: https://rive.app/community/doc/overview/docD20dU9Rod
  //
  // This is optional. The current defaults are:
  // - iOS: Skia
  // - Android: Skia
  // In the future the default will be the Rive Renderer (RiveRendererIOS.Rive and RiveRendererAndroid.Rive)
  //
  useEffect(() => {
    RiveRenderer.defaultRenderer(
      RiveRendererIOS.Rive,
      RiveRendererAndroid.Skia
    );
  }, []);

  return <App />;
}
```

For more information, see: https://rive.app/community/doc/overview/docD20dU9Rod

Options are:
- iOS: `skia` (default), `rive`, and `coreGraphics`
- Android: `skia` (default), `rive`, and `canvas`

Rive will be the default in a future release.