### PR TITLE
chore: release v7.1.1

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -487,10 +487,10 @@ PODS:
     - React-jsi (= 0.72.7)
     - React-logger (= 0.72.7)
     - React-perflogger (= 0.72.7)
-  - rive-react-native (7.0.5):
+  - rive-react-native (7.1.1):
     - React-Core
-    - RiveRuntime (= 5.12.0)
-  - RiveRuntime (5.12.0)
+    - RiveRuntime (= 5.12.1)
+  - RiveRuntime (5.12.1)
   - RNCMaskedView (0.2.9):
     - React-Core
   - RNCPicker (1.16.8):
@@ -744,8 +744,8 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 7649c3b46c8dee1853691ecf60146a16ae59253c
   React-utils: 56838edeaaf651220d1e53cd0b8934fb8ce68415
   ReactCommon: 5f704096ccf7733b390f59043b6fa9cc180ee4f6
-  rive-react-native: df5727c937700a82018cf6a1ee12fbf5e4cc0296
-  RiveRuntime: 9568f984e8f8489ec1198268b09b496890d0efdc
+  rive-react-native: 38dbcff37fd7f4f3184f4496699d755ebf72a699
+  RiveRuntime: a2482cbb5c56acc0ca7312e1983095bfa302dfc5
   RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
   RNCPicker: 0991c56da7815c0cf946d6f63cf920b25296e5f6
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rive-react-native",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "Rive React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -50,8 +50,8 @@
     "@commitlint/config-conventional": "^11.0.0",
     "@react-native-community/eslint-config": "^2.0.0",
     "@react-native/metro-config": "^0.72.11",
-    "@tsconfig/react-native": "^3.0.0",
     "@release-it/conventional-changelog": "^2.0.0",
+    "@tsconfig/react-native": "^3.0.0",
     "@types/jest": "^26.0.0",
     "@types/react": "^18.0.24",
     "@types/react-native": "0.72.2",

--- a/rive-react-native.podspec
+++ b/rive-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "RiveRuntime", "5.12.0"
+  s.dependency "RiveRuntime", "5.12.1"
 end


### PR DESCRIPTION
Bump iOS to `v5.12.1`, see [iOS Changelog](https://github.com/rive-app/rive-ios/blob/main/CHANGELOG.md)
- Fix libjpg on Mac Sonomaios
- only start/stop the audio engine if it has been initialized