### PR TITLE
feat: add updatable referenced assets

### DIFF
--- a/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
@@ -571,6 +571,7 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
     this.referencedAssets = referencedAssets
 
     if (previousReferencedAssets == null || referencedAssets == null) {
+      shouldBeReloaded = true
       return
     }
 
@@ -933,11 +934,11 @@ private class RiveReactNativeAssetStore(
   var cachedFileAssets: MutableMap<String, FileAsset> = mutableMapOf()
 
   override fun loadContents(asset: FileAsset, inBandBytes: ByteArray): Boolean {
-    var usedKey = asset.uniqueFilename.substringBeforeLast(".")
-    var assetData = referencedAssets.getMap(usedKey)
+    var key = asset.uniqueFilename.substringBeforeLast(".")
+    var assetData = referencedAssets.getMap(key)
     if (assetData == null) {
       // Try to find an assets by matching the name only
-      usedKey = asset.name
+      key = asset.name
       assetData = referencedAssets.getMap(asset.name)
     }
 
@@ -951,7 +952,7 @@ private class RiveReactNativeAssetStore(
         // This is here as a precaution and to potentially handle other errors in the future.
       }
     }
-    cachedFileAssets[usedKey] = asset
+    cachedFileAssets[key] = asset
     return true // user supplied asset, attempt to load
   }
 

--- a/example/app/(examples)/OutOfBandAssets.tsx
+++ b/example/app/(examples)/OutOfBandAssets.tsx
@@ -1,63 +1,84 @@
-import { SafeAreaView, ScrollView, StyleSheet, Text } from 'react-native';
+import * as React from 'react';
+import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 import Rive, { Fit, RNRiveError } from 'rive-react-native';
+import { Picker } from '@react-native-picker/picker';
 
 export default function StateMachine() {
+  const [uri, setUri] = React.useState('https://picsum.photos/id/372/500/500');
+
   return (
     <SafeAreaView style={styles.safeAreaViewContainer}>
+      <Rive
+        autoplay={true}
+        fit={Fit.Contain}
+        style={styles.animation}
+        stateMachineName="State Machine 1"
+        // The `referencedAssets` prop allows you to load external assets from various sources:
+        // - A URI
+        // - A bundled asset on the native platform (iOS and Android)
+        // - A source loaded directly from JavaScript.
+        //
+        // This example demonstrates multiple ways to load the same asset from different locations.
+        // Note: It's not necessary to store the same asset in all these locations; this is for demonstration purposes.
+        //
+        // The key of the map is the unique asset identifier (as exported in the Editor),
+        // which combines the asset name and its unique identifier.
+        // You can optionally exclude the unique identifier, for example, instead of 'Inter-594377', you can use 'Inter'.
+        // However, it is recommended to use the full identifier to avoid potential conflicts.
+        // Using just the asset name allows you to avoid knowing the unique identifier and gives you more control over naming.
+        referencedAssets={{
+          'Inter-594377': {
+            source: require('../../assets/fonts/Inter-594377.ttf'),
+            // source: {
+            //   fileName: 'Inter-594377.ttf',
+            //   path: 'fonts', // only needed for Android assets
+            // },
+          },
+          'referenced-image-2929282': {
+            source: {
+              uri: uri,
+            },
+            // source: {
+            //   fileName: 'referenced-image-2929282.png',
+            //   path: 'images', // only needed for Android assets
+            // },
+          },
+          'referenced_audio-2929340': {
+            source: require('../../assets/audio/referenced_audio-2929340.wav'),
+            // source: {
+            //   fileName: 'referenced_audio-2929340.wav',
+            //   path: 'audio', // only needed for Android assets
+            // },
+          },
+        }}
+        artboardName="Artboard"
+        resourceName={'out_of_band'}
+        onError={(riveError: RNRiveError) => {
+          console.log(riveError);
+        }}
+      />
+      {/* <Text>
+        Load in an external asset from a URL, or bundled asset on the native
+        platform, or as a source loaded directly from JavaScript.
+      </Text> */}
       <ScrollView contentContainerStyle={styles.container}>
-        <Rive
-          autoplay={true}
-          fit={Fit.Contain}
-          style={styles.box}
-          stateMachineName="State Machine 1"
-          // The `referencedAssets` prop allows you to load external assets from various sources:
-          // - A URI
-          // - A bundled asset on the native platform (iOS and Android)
-          // - A source loaded directly from JavaScript.
-          //
-          // This example demonstrates multiple ways to load the same asset from different locations.
-          // Note: It's not necessary to store the same asset in all these locations; this is for demonstration purposes.
-          //
-          // The key of the map is the unique asset identifier (as exported in the Editor),
-          // which combines the asset name and its unique identifier.
-          // You can optionally exclude the unique identifier, for example, instead of 'Inter-594377', you can use 'Inter'.
-          // However, it is recommended to use the full identifier to avoid potential conflicts.
-          // Using just the asset name allows you to avoid knowing the unique identifier and gives you more control over naming.
-          referencedAssets={{
-            'Inter-594377': {
-              source: require('../../assets/fonts/Inter-594377.ttf'),
-              // source: {
-              //   fileName: 'Inter-594377.ttf',
-              //   path: 'fonts', // only needed for Android assets
-              // },
-            },
-            'referenced-image-2929282': {
-              source: {
-                uri: 'https://picsum.photos/id/270/500/500',
-              },
-              // source: {
-              //   fileName: 'referenced-image-2929282.png',
-              //   path: 'images', // only needed for Android assets
-              // },
-            },
-            'referenced_audio-2929340': {
-              source: require('../../assets/audio/referenced_audio-2929340.wav'),
-              // source: {
-              //   fileName: 'referenced_audio-2929340.wav',
-              //   path: 'audio', // only needed for Android assets
-              // },
-            },
-          }}
-          artboardName="Artboard"
-          resourceName={'out_of_band'}
-          onError={(riveError: RNRiveError) => {
-            console.log(riveError);
-          }}
-        />
-        <Text>
-          Load in an external asset from a URL, or bundled asset on the native
-          platform, or as a source loaded directly from JavaScript.
-        </Text>
+        <View style={styles.pickersWrapper}>
+          <View style={styles.pickerWrapper}>
+            <Picker
+              selectedValue={uri}
+              onValueChange={(value) => setUri(value)}
+              mode={'dropdown'}
+              style={styles.picker}
+            >
+              {[
+                'https://picsum.photos/id/372/500/500',
+                'https://picsum.photos/id/373/500/500',
+              ].map((key) => (
+                <Picker.Item key={key} value={key} label={key} />
+              ))}
+            </Picker>
+          </View>
+        </View>
       </ScrollView>
     </SafeAreaView>
   );
@@ -70,13 +91,26 @@ const styles = StyleSheet.create({
   container: {
     flexGrow: 1,
     alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 150,
-    padding: 10,
+    justifyContent: 'flex-start',
   },
-  box: {
+  animation: {
     width: '100%',
-    height: 500,
-    marginVertical: 20,
+    height: 400,
+  },
+  picker: {
+    flex: 1,
+    width: '100%',
+  },
+  pickerWrapper: {
+    borderWidth: 1,
+    borderColor: 'black',
+    borderRadius: 5,
+    alignItems: 'center',
+    margin: 16,
+  },
+  pickersWrapper: {
+    flex: 1,
+    padding: 16,
+    alignSelf: 'stretch',
   },
 });

--- a/example/app/(examples)/OutOfBandAssets.tsx
+++ b/example/app/(examples)/OutOfBandAssets.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView, ScrollView, StyleSheet, View } from 'react-native';
 import Rive, { Fit, RNRiveError } from 'rive-react-native';
 import { Picker } from '@react-native-picker/picker';
 

--- a/ios/RiveReactNativeView.swift
+++ b/ios/RiveReactNativeView.swift
@@ -245,7 +245,7 @@ class RiveReactNativeView: RCTView, RivePlayerDelegate, RiveStateMachineDelegate
             guard let keyString = key as? String,
                 let cachedValue = cachedReferencedAssets[keyString] as? NSDictionary,
                 let newValue = value as? NSDictionary,
-                !cachedValue.isEqual(newValue) else {
+                  !cachedValue.isEqual(to: newValue as! [AnyHashable : Any]) else {
                 continue
             }
 
@@ -258,8 +258,8 @@ class RiveReactNativeView: RCTView, RivePlayerDelegate, RiveStateMachineDelegate
         }
 
         if hasChanged && viewModel?.isPlaying == false {
-            riveView?.advance(delta: 0);
-//            viewModel?.play()  manually calling play to force an update, ideally want to do a single advance
+//            riveView?.advance(delta: 0);            
+           viewModel?.play() // manually calling play to force an update, ideally want to do a single advance
         }
     }
 


### PR DESCRIPTION
This PR exposes a way to update referenced assets by modifying the properties that are passed in through the view.

Previously, it would result in the entire `riv` file being reloaded. Now it's possible to update specific referenced assets without reloading the .riv file. Steps in the underlying implementation:
- Conditionally check to see if the assets have changed. This is a combination of name (key) and source (value)
- If there is a change, only update the assets that have a new source
- Uses the same mechanisms that are currently available to load in the asset

Example JS code:
```js
// Initial value
const [uri, setUri] = React.useState('https://picsum.photos/id/372/500/500');

...

<Rive
  autoplay={true}
  fit={Fit.Contain}
  style={styles.animation}
  stateMachineName="State Machine 1"
 // Specify the referenced asset to load. If the keys, in this case `referenced-image-2929282`,
 // stay the same it won't cause the .riv file to be reloaded.
// If the `source` changes it'll update the referenced asset
  referencedAssets={{
    'referenced-image-2929282': {
      source: {
        uri: uri,
      },
    },
  }}
  artboardName="Artboard"
  resourceName={'out_of_band'}
  onError={(riveError: RNRiveError) => {
    console.log(riveError);
  }}
/>

...

// Later update
setUri('https://picsum.photos/id/370/500/500')
```
