### PR TITLE
Fix: touching the rive can cause a crash on iOS

### DIFF
--- a/ios/RiveReactNativeView.swift
+++ b/ios/RiveReactNativeView.swift
@@ -603,7 +603,7 @@ class RiveReactNativeView: RCTView, RivePlayerDelegate, RiveStateMachineDelegate
         if let viewModel = viewModel, let riveView = viewModel.riveView {
             let artboardLocation = riveView.artboardLocation(
                 fromTouchLocation: location,
-                inArtboard: viewModel.riveModel!.artboard!.bounds(),
+                inArtboard: viewModel.riveModel?.artboard?.bounds() ?? CGRect.zero,
                 fit: viewModel.fit,
                 alignment: viewModel.alignment
             )


### PR DESCRIPTION
So I had a weird crash found in my app when clicking the rive at a certain point (something like the exit state). The crash seemed to be caused by the `handleTouch` method from `RiveReactNativeView.swift`. 

Specifically at this line:
`inArtboard: viewModel.riveModel!.artboard!.bounds()` where Xcode would throw `Unexpectedly found nil while unwrapping an Optional value`.

The fix proposed by gpt was the one from the PR.

Hope I didn't mess any contributing rules, as this is my first fork + PR contribution, and I hope it helps.