### PR TITLE
[Android]: Press events did not work correctly

### DIFF
--- a/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
@@ -355,11 +355,11 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
   }
 
   fun touchBegan(x: Float, y: Float) {
-    riveAnimationView?.controller?.pointerEvent(PointerEvents.POINTER_DOWN, x, y)
+    // riveAnimationView?.controller?.pointerEvent(PointerEvents.POINTER_DOWN, x, y)
   }
 
   fun touchEnded(x: Float, y: Float) {
-    riveAnimationView?.controller?.pointerEvent(PointerEvents.POINTER_UP, x, y)
+    // riveAnimationView?.controller?.pointerEvent(PointerEvents.POINTER_UP, x, y)
   }
 
   fun setTextRunValue(textRunName: String, textValue: String) {


### PR DESCRIPTION
Hello everyone. I have never made any contributions before, and this is my first time. I encountered a problem using a library on Android, so I decided to play around with the code. I accidentally commented out these two lines, and my problem was solved. Below are two examples; I don't know about the other use cases. I'm unfamiliar with native library development, so I'm not sure what this code does, but everything works now, just like on iOS.

Fixes https://github.com/rive-app/rive-react-native/issues/224

| Working | Not Working |
|--------|--------|
| ![my own example](https://github.com/user-attachments/assets/76a8fe1d-049b-4d3e-bda1-07da8d2276e8) | ![my own not working](https://github.com/user-attachments/assets/84c8696c-2845-4ed4-b7a6-25d682feb603) |
| ![example from issue](https://github.com/user-attachments/assets/755c0253-4530-45e4-b249-81317ec6d8ed) | ![issue example not working](https://github.com/user-attachments/assets/2a84697c-d257-4c32-b16a-4b26d43073d7) | 