### PR TITLE
Fix loading of file:// URLs in Android release

### DIFF
--- a/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rivereactnative/RiveReactNativeView.kt
@@ -993,13 +993,12 @@ class RiveReactNativeView(private val context: ThemedReactContext) : FrameLayout
       return
     }
 
-    val queue = Volley.newRequestQueue(context)
-
-    val stringRequest = RNRiveFileRequest(
-      url, listener
-    ) { error -> handleURLAssetError(url, error, isUserHandlingErrors) }
-
-    queue.add(stringRequest)
+    val loader = ResourceLoaderFactory.getLoader(url, context)
+    loader.loadResource(
+      url,
+      listener,
+      { error -> handleURLAssetError(url, error, isUserHandlingErrors) }
+    )
   }
 
   private fun processAssetBytes(bytes: ByteArray, asset: FileAsset) {
@@ -1220,3 +1219,61 @@ data class PropertyListener(
   val propertyType: String,
   val job: Job
 )
+
+interface ResourceLoader {
+  fun loadResource(
+    url: String,
+    listener: Response.Listener<ByteArray>,
+    errorListener: Response.ErrorListener
+  )
+}
+
+// Standard Volley HTTP implementation
+class VolleyHttpLoader(private val context: ThemedReactContext) : ResourceLoader {
+  override fun loadResource(
+    url: String,
+    listener: Response.Listener<ByteArray>,
+    errorListener: Response.ErrorListener
+  ) {
+    // Use your existing RNRiveFileRequest for HTTP
+    val queue = Volley.newRequestQueue(context)
+
+    val request = RNRiveFileRequest(
+      url, listener, errorListener
+    )
+
+    queue.add(request)
+  }
+}
+
+// Direct file system implementation
+class FileSystemLoader : ResourceLoader {
+  override fun loadResource(
+    url: String,
+    listener: Response.Listener<ByteArray>,
+    errorListener: Response.ErrorListener
+  ) {
+    try {
+      // Extract file path from file:// URL
+      val filePath = url.substring(7) // Remove "file://"
+      val file = java.io.File(filePath)
+
+      // Read file directly
+      val data = file.readBytes()
+      listener.onResponse(data)
+    } catch (e: Exception) {
+      // Pretend the error came from Volley, which is how http URLs are loaded
+      errorListener.onErrorResponse(VolleyError(e))
+    }
+  }
+}
+
+// Factory class that returns the appropriate loader
+object ResourceLoaderFactory {
+  fun getLoader(url: String, context: ThemedReactContext): ResourceLoader {
+    return when {
+      url.startsWith("file://") -> FileSystemLoader()
+      else -> VolleyHttpLoader(context)
+    }
+  }
+}


### PR DESCRIPTION
This updates the definition of `RiveReactNativeView.downloadUrlAsset` to load `file://` URLs via `java.io.File`

Formerly, if a `file://` URL was loaded, that would lead to `com.android.volley.VolleyError: java.lang.ClassCastException: sun.net.www.protocol.file.FileURLConnection cannot be cast to java.net.HttpURLConnection`

This only affects Android apps built in release mode, as debug mode is unaffected.