### PR TITLE
chore: release 9.5.0

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1690,7 +1690,7 @@ PODS:
     - React-logger (= 0.76.7)
     - React-perflogger (= 0.76.7)
     - React-utils (= 0.76.7)
-  - rive-react-native (9.4.0):
+  - rive-react-native (9.5.0):
     - React-Core
     - RiveRuntime (= 6.11.1)
   - RiveRuntime (6.11.1)
@@ -2222,7 +2222,7 @@ SPEC CHECKSUMS:
   React-utils: 0342746d2cf989cf5e0d1b84c98cfa152edbdf3f
   ReactCodegen: e1c019dc68733dd2c5d3b263b4a6dc72002c0045
   ReactCommon: 81e0744ee33adfd6d586141b927024f488bc49ea
-  rive-react-native: f46033e47ce77b04cbfddb7344feb7c188bac5f1
+  rive-react-native: 9e05a263d7d5325c710128d234dc48820b3b4323
   RiveRuntime: 3a34dd73b2d486558f3077af408b3b2734653f3f
   RNCPicker: c657bd58a82b164a957812f82a0b4bab4245de2e
   RNGestureHandler: 16ef3dc2d7ecb09f240f25df5255953c4098819b

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rive-react-native",
-  "version": "9.4.0",
+  "version": "9.5.0",
   "workspaces": [
     "example"
   ],


### PR DESCRIPTION
Action failed, manually bumping and tagging after