### PR TITLE
feat: add native SDK version customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This library is a wrapper around the iOS/Android runtime, providing a component 
 - 🏃 [Migration Guides](#migration-guides)
 - 👨‍💻 [Contributing](#contributing)
 - :question: [Issues](#issues)
+- :wrench: [Native SDK Version Customization](#native-sdk-version-customization)
 
 ## Rive Overview
 
@@ -77,3 +78,90 @@ We love contributions! Check out our [contributing docs](./CONTRIBUTING.md) to g
 ## Issues
 
 Have an issue with using the runtime, or want to suggest a feature/API to help make your development life better? Log an issue in our [issues](https://github.com/rive-app/rive-react-native/issues) tab! You can also browse older issues and discussion threads there to see solutions that may have worked for common problems.
+
+## Native SDK Version Customization
+
+> **⚠️ Advanced Configuration**
+> This section is for advanced users who need to use specific versions of the Rive native SDKs. In most cases, you should use the default versions that come with the library. Only customize these versions if you have a specific requirement and understand the potential compatibility implications.
+>
+> **Important:** If you customize the native SDK versions and later update `rive-react-native` to a newer version, you should revisit your custom version settings. The custom versions you specified may not be compatible with the updated `rive-react-native` version. Always check the default versions in the new release and test thoroughly.
+
+### Default Behavior
+
+By default, `rive-react-native` uses the native SDK versions specified in `package.json`:
+
+```json
+"runtimeVersions": {
+  "ios": "6.12.0",
+  "android": "10.4.5"
+}
+```
+
+These versions are tested and known to work well with this version of `rive-react-native`.
+
+### Customizing Versions
+
+You can override these default versions using platform-specific configuration files:
+
+#### iOS (Vanilla React Native)
+
+Create or edit `ios/Podfile.properties.json`:
+
+```json
+{
+  "RiveRuntimeIOSVersion": "6.13.0"
+}
+```
+
+Then run:
+```bash
+cd ios && pod install
+```
+
+#### Android (Vanilla React Native)
+
+Add to `android/gradle.properties`:
+
+```properties
+Rive_RiveRuntimeAndroidVersion=10.5.0
+```
+
+#### Expo Projects
+
+For Expo projects, use config plugins in your `app.config.ts`:
+
+```typescript
+import { ExpoConfig, ConfigContext } from 'expo/config';
+import { withPodfileProperties } from '@expo/config-plugins';
+import { withGradleProperties } from '@expo/config-plugins';
+
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  ...config,
+  plugins: [
+    [
+      withPodfileProperties,
+      {
+        RiveRuntimeIOSVersion: '6.13.0',
+      },
+    ],
+    [
+      withGradleProperties,
+      {
+        Rive_RiveRuntimeAndroidVersion: '10.5.0',
+      },
+    ],
+  ],
+});
+```
+
+### Version Resolution Priority
+
+The library resolves versions in the following order:
+
+**iOS:**
+1. `ios/Podfile.properties.json` → `RiveRuntimeIOSVersion`
+2. `package.json` → `runtimeVersions.ios` (default)
+
+**Android:**
+1. `android/gradle.properties` → `Rive_RiveRuntimeAndroidVersion`
+2. `package.json` → `runtimeVersions.android` (default)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -128,6 +128,25 @@ repositories {
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
 
+def getRiveAndroidVersion() {
+  if (project.hasProperty("Rive_RiveRuntimeAndroidVersion")) {
+    return project.property("Rive_RiveRuntimeAndroidVersion")
+  }
+
+  def packageJsonFile = new File(projectDir, '../package.json')
+  if (packageJsonFile.exists()) {
+    def packageJson = new groovy.json.JsonSlurper().parseText(packageJsonFile.text)
+    if (packageJson.runtimeVersions?.android) {
+      return packageJson.runtimeVersions.android
+    }
+  }
+
+  throw new GradleException("Could not determine Rive Android SDK version. Please add 'runtimeVersions.android' to package.json")
+}
+
+def riveAndroidVersion = getRiveAndroidVersion()
+println "rive-react-native: Using Rive Android SDK ${riveAndroidVersion}"
+
 dependencies {
   // noinspection GradleDynamicVersion
   def lifecycle_version = "2.6.1"
@@ -138,7 +157,7 @@ dependencies {
   implementation 'androidx.core:core-ktx:1.12.0'
   implementation 'androidx.appcompat:appcompat:1.6.1'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
-  implementation 'app.rive:rive-android:10.4.5'
+  implementation "app.rive:rive-android:${riveAndroidVersion}"
   implementation "androidx.startup:startup-runtime:1.1.1"
   implementation 'com.android.volley:volley:1.2.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "rive-react-native",
   "version": "9.6.2",
+  "runtimeVersions": {
+    "ios": "6.12.0",
+    "android": "10.4.5"
+  },
   "workspaces": [
     "example"
   ],

--- a/rive-react-native.podspec
+++ b/rive-react-native.podspec
@@ -2,6 +2,21 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
+# Resolve Rive iOS SDK version
+podfile_properties_path = File.join(__dir__, "ios", "Podfile.properties.json")
+if File.exist?(podfile_properties_path)
+  podfile_properties = JSON.parse(File.read(podfile_properties_path))
+  rive_ios_version = podfile_properties["RiveRuntimeIOSVersion"]
+end
+
+rive_ios_version ||= package["runtimeVersions"]["ios"]
+
+if rive_ios_version.nil?
+  raise "Could not determine Rive iOS SDK version. Please add 'runtimeVersions.ios' to package.json"
+end
+
+Pod::UI.puts "rive-react-native: Using Rive iOS SDK #{rive_ios_version}"
+
 Pod::Spec.new do |s|
   s.name         = "rive-react-native"
   s.version      = package["version"]
@@ -18,5 +33,5 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   s.dependency "React-Core"
-  s.dependency "RiveRuntime", "6.12.0"
+  s.dependency "RiveRuntime", rive_ios_version
 end


### PR DESCRIPTION
Adds support for customizable Rive native SDK versions, allowing users to override the default iOS and Android runtime versions without modifying library code.

Users can specify custom versions via `ios/Podfile.properties.json` and `android/gradle.properties`, with automatic fallback to defaults in `package.json`. Includes documentation for both vanilla React Native and Expo projects.