### PR TITLE
feat: warn for unreferenced assets

### DIFF
--- a/android/src/main/java/com/rivereactnative/RNRiveError.kt
+++ b/android/src/main/java/com/rivereactnative/RNRiveError.kt
@@ -12,7 +12,8 @@ enum class RNRiveError(private val mValue: String) {
   IncorrectStateMachineName("IncorrectStateMachineName"),
   IncorrectStateMachineInput("IncorrectStateMachineInput"),
   TextRunNotFoundError("TextRunNotFoundError"),
-  DataBindingError("DataBindingError");
+  DataBindingError("DataBindingError"),
+  UnusedReferencedAssetError("UnusedReferencedAssetError");
 
   var message: String = "Default message"
 

--- a/ios/RNRiveError.swift
+++ b/ios/RNRiveError.swift
@@ -15,6 +15,7 @@ struct RNRiveError {
     static let IncorrectStateMachineInput = BaseRNRiveError(type: "IncorrectStateMachineInput")
     static let TextRunNotFoundError = BaseRNRiveError(type: "TextRunNotFoundError")
     static let DataBindingError = BaseRNRiveError(type: "DataBindingError")
+    static let UnusedReferencedAssetError = BaseRNRiveError(type: "UnusedReferencedAssetError")
     
     
     static func mapToRNRiveError(riveError: NSError) -> BaseRNRiveError? {

--- a/ios/RiveReactNativeView.swift
+++ b/ios/RiveReactNativeView.swift
@@ -331,6 +331,7 @@ class RiveReactNativeView: RCTView, RivePlayerDelegate, RiveStateMachineDelegate
             } else {
                 updatedViewModel = RiveViewModel(fileName: name, fit: convertFit(fit), alignment: convertAlignment(alignment), autoPlay: autoplay, artboardName: artboardName, customLoader: customLoader)
             }
+            warnForUnusedAssets()
             
             updatedViewModel.layoutScaleFactor = layoutScaleFactor.doubleValue
             
@@ -451,6 +452,26 @@ class RiveReactNativeView: RCTView, RivePlayerDelegate, RiveStateMachineDelegate
         }
         
         return false
+    }
+
+    private func warnForUnusedAssets() {
+        guard let referencedAssets = referencedAssets else { return }
+
+        let providedKeys = Set(referencedAssets.allKeys.compactMap { $0 as? String })
+        let referencedInFileKeys = Set(cachedFileAssets.keys)
+        let unusedKeys = providedKeys.subtracting(referencedInFileKeys)
+        if !unusedKeys.isEmpty {
+            let keysString = unusedKeys.joined(separator: ",")
+            let message = "referencesAsset provided keys: \(keysString) but it was not referenced in the rive file"
+            if isUserHandlingErrors {
+                var error = RNRiveError.UnusedReferencedAssetError
+                error.message = message
+                onRNRiveError(error)
+            } else {
+              RCTLogWarn(message)
+              
+            }
+        }
     }
     
     private func loadAsset(source: NSDictionary, asset: RiveFileAsset, factory: RiveFactory) {

--- a/src/Rive.tsx
+++ b/src/Rive.tsx
@@ -628,6 +628,11 @@ const RiveContainer = React.forwardRef<RiveRef, Props>(
         const rnRiveError = convertErrorFromNativeToRN({ type, message });
         if (rnRiveError !== null) {
           onError?.(rnRiveError);
+        } else {
+          console.warn(
+            '[Rive] Unknown error type received from native: ',
+            type
+          );
         }
       },
       [onError]

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,7 @@ export enum RNRiveErrorType {
   IncorrectStateMachineInput = 'IncorrectStateMachineInput',
   TextRunNotFoundError = 'TextRunNotFoundError',
   DataBindingError = 'DataBindingError',
+  UnusedReferencedAssetError = 'UnusedReferencedAssetError',
 }
 
 export type RNRiveError = {


### PR DESCRIPTION
Fixes: #383

Implements UnusedReferencedAssetError warning on both iOS and Android to help developers catch typos and configuration errors when providing referenced asset keys. When a key is provided in referencedAssets that doesn't match any asset in the .riv file, a warning is now reported via the onError callback or logged to console.

# To reproduce
Modify the [OutOfBandAssets.tsx](https://github.com/rive-app/rive-react-native/blob/main/example/app/(examples)/OutOfBandAssets.tsx#L51) example to include a test case with an
  intentionally incorrect asset key:

```
  'no-such-asset-123': {
    source:
  require('../../assets/audio/referenced_audio-2929340.wav'),
  },
``` 

  To reproduce:
  1. Run the example app on iOS or Android
  2. Navigate to the OutOfBandAssets example
  3. Check the onError callback output (line 60-62) or console
  logs

  Expected behavior:
  - With onError provided: Error object with type: 
  'UnusedReferencedAssetError' and message: "referencedAssets 
  provided keys: no-such-asset-123 but they were not referenced in
   the rive file"
  - Without onError:
    - iOS: Yellow box warning via RCTLogWarn
    - Android: Warning in logcat