### PR TITLE
fix: iOS broken builds because of an extra space character

### DIFF
--- a/ios/RiveReactNativeViewManager.swift
+++ b/ios/RiveReactNativeViewManager.swift
@@ -17,7 +17,7 @@ class RiveReactNativeViewManager: RCTViewManager {
                 return
             }
 
-            guard let view = bridge.uiMan ager.view(forReactTag: node) else {
+            guard let view = bridge.uiManager.view(forReactTag: node) else {
                 RCTSwiftLog.error("Could not find view with tag: \(node)", file: file, line:line)
                 return
             }


### PR DESCRIPTION
This extra space slipped in recently and is breaking iOS.