### PR TITLE
fix: remove touchable layer in JS to avoid duplicated pointer events

### DIFF
--- a/src/Rive.tsx
+++ b/src/Rive.tsx
@@ -17,8 +17,6 @@ import {
   NativeSyntheticEvent,
   StyleSheet,
   View,
-  TouchableWithoutFeedback,
-  GestureResponderEvent,
   StyleProp,
   NativeModules,
   NativeEventEmitter,
@@ -1026,38 +1024,29 @@ const RiveContainer = React.forwardRef<RiveRef, Props>(
     return (
       <View style={[styles.container, style]} ref={ref as any} testID={testID}>
         <View style={styles.children}>{children}</View>
-        <TouchableWithoutFeedback
-          onPressIn={(event: GestureResponderEvent) =>
-            touchBegan(event.nativeEvent.locationX, event.nativeEvent.locationY)
-          }
-          onPressOut={(event: GestureResponderEvent) =>
-            touchEnded(event.nativeEvent.locationX, event.nativeEvent.locationY)
-          }
-        >
-          <RiveViewManager
-            ref={riveRef}
-            resourceName={resourceName}
-            isUserHandlingErrors={isUserHandlingErrors}
-            autoplay={autoplay}
-            fit={fit}
-            layoutScaleFactor={layoutScaleFactor}
-            url={url}
-            style={styles.animation}
-            onPlay={onPlayHandler}
-            onPause={onPauseHandler}
-            onStop={onStopHandler}
-            onLoopEnd={onLoopEndHandler}
-            onStateChanged={onStateChangedHandler}
-            onRiveEventReceived={onRiveEventReceivedHandler}
-            onError={onErrorHandler}
-            alignment={alignment}
-            artboardName={artboardName}
-            referencedAssets={convertedAssetHandledSources}
-            dataBinding={dataBinding}
-            animationName={animationName}
-            stateMachineName={stateMachineName}
-          />
-        </TouchableWithoutFeedback>
+        <RiveViewManager
+          ref={riveRef}
+          resourceName={resourceName}
+          isUserHandlingErrors={isUserHandlingErrors}
+          autoplay={autoplay}
+          fit={fit}
+          layoutScaleFactor={layoutScaleFactor}
+          url={url}
+          style={styles.animation}
+          onPlay={onPlayHandler}
+          onPause={onPauseHandler}
+          onStop={onStopHandler}
+          onLoopEnd={onLoopEndHandler}
+          onStateChanged={onStateChangedHandler}
+          onRiveEventReceived={onRiveEventReceivedHandler}
+          onError={onErrorHandler}
+          alignment={alignment}
+          artboardName={artboardName}
+          referencedAssets={convertedAssetHandledSources}
+          dataBinding={dataBinding}
+          animationName={animationName}
+          stateMachineName={stateMachineName}
+        />
       </View>
     );
   }


### PR DESCRIPTION
This might need a larger discussion if we ever wanted to block touch events on native iOS and Android, and instead use the JS layer to send events.

However, right now, it seems like we're doing both. Under most circumstances this does not cause an issue, but on Android (because of the threaded nature) certain pointer interactions (click) aren't working. I assume that the click is receiving multiple pointer-down events that do not map to the correct pointer up.

Regardless, there is currently no need for the JS touch layer (which is also not covering all pointer logic, move/cancel/etc.)

This is especially true due to recent developments on iOS and Android to cater towards multi-touch which adds further complication. Let's stick with the native layer handling this. But we'll keep the bridging code in case someone is currently calling these through the view ref.

At the Editor/Native level, we will also be redoing the whole input model. We can revisit this for the new React Native rewrite, when the above is implemented.