### PR TITLE
chore: bump native runtimes (iOS 6.18.2, Android 11.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ By default, `rive-react-native` uses the native SDK versions specified in `packa
 
 ```json
 "runtimeVersions": {
-  "ios": "6.15.2",
-  "android": "11.2.0"
+  "ios": "6.18.2",
+  "android": "11.4.0"
 }
 ```
 
@@ -128,7 +128,7 @@ Create or edit `ios/Podfile.properties.json`:
 
 ```json
 {
-  "RiveRuntimeIOSVersion": "6.15.2"
+  "RiveRuntimeIOSVersion": "6.18.2"
 }
 ```
 
@@ -143,7 +143,7 @@ cd ios && pod install
 Add to `android/gradle.properties`:
 
 ```properties
-Rive_RiveRuntimeAndroidVersion=11.2.0
+Rive_RiveRuntimeAndroidVersion=11.4.0
 ```
 
 #### Expo Projects
@@ -161,13 +161,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       withPodfileProperties,
       {
-        RiveRuntimeIOSVersion: '6.15.2',
+        RiveRuntimeIOSVersion: '6.18.2',
       },
     ],
     [
       withGradleProperties,
       {
-        Rive_RiveRuntimeAndroidVersion: '11.2.0',
+        Rive_RiveRuntimeAndroidVersion: '11.4.0',
       },
     ],
   ],

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1690,10 +1690,10 @@ PODS:
     - React-logger (= 0.76.7)
     - React-perflogger (= 0.76.7)
     - React-utils (= 0.76.7)
-  - rive-react-native (9.7.1):
+  - rive-react-native (9.8.1):
     - React-Core
-    - RiveRuntime (= 6.15.2)
-  - RiveRuntime (6.15.2)
+    - RiveRuntime (= 6.18.2)
+  - RiveRuntime (6.18.2)
   - RNCPicker (2.11.0):
     - DoubleConversion
     - glog
@@ -2222,8 +2222,8 @@ SPEC CHECKSUMS:
   React-utils: 0342746d2cf989cf5e0d1b84c98cfa152edbdf3f
   ReactCodegen: e1c019dc68733dd2c5d3b263b4a6dc72002c0045
   ReactCommon: 81e0744ee33adfd6d586141b927024f488bc49ea
-  rive-react-native: 9f14e5bd0fc53537a6d04c0164163cc6bd994f94
-  RiveRuntime: b2c29a7e1fbf2aabd1fffcb7b9cf43c4d515a841
+  rive-react-native: 42e74b37776e61588e28acb1e3066f37fdd55bbd
+  RiveRuntime: 55c7a7badd9a8389d20fc8a75b7c6accc851b69a
   RNCPicker: c657bd58a82b164a957812f82a0b4bab4245de2e
   RNGestureHandler: 16ef3dc2d7ecb09f240f25df5255953c4098819b
   RNReanimated: a2692304a6568bc656c04c8ffea812887d37436e

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "rive-react-native",
   "version": "9.8.1",
   "runtimeVersions": {
-    "ios": "6.15.2",
-    "android": "11.2.0"
+    "ios": "6.18.2",
+    "android": "11.4.0"
   },
   "workspaces": [
     "example"


### PR DESCRIPTION
Bump native Rive runtimes from iOS 6.15.2 → 6.18.2 and Android 11.2.0 → 11.4.0.

Notable changes in native runtimes:

**iOS 6.18.2** ([full changelog](https://github.com/rive-app/rive-ios/releases/tag/6.18.2)):
- feat: expose view model name from view model instance
- feat: audio duration API
- feat(vulkan): pre-build draw pipelines
- fix(renderer): gamma correction fix
- fix: path effect shape for inner vector feathering
- fix(runtime): memory leak with listeners on scripted view model properties

**iOS 6.18.0** ([full changelog](https://github.com/rive-app/rive-ios/releases/tag/6.18.0)):
- feature: component based conditions
- fix: data bound inputs in data converters
- fix: path effect advance
- fix(runtime): interpolation duration zero reset
- feat: Image Fit & Alignment when parented by Layout

**Android 11.4.0** ([full changelog](https://github.com/rive-app/rive-android/releases/tag/11.4.0)):
- feature: component based conditions
- feat: single/multiline support in TextInput and improved scrolling
- fix(Vulkan): saturation blend mode on some devices
- fix: data bound inputs in data converters
- fix: path effect advance