### PR TITLE
fix: bump iOS runtime (6.19.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ By default, `rive-react-native` uses the native SDK versions specified in `packa
 
 ```json
 "runtimeVersions": {
-  "ios": "6.18.2",
+  "ios": "6.19.0",
   "android": "11.4.0"
 }
 ```
@@ -128,7 +128,7 @@ Create or edit `ios/Podfile.properties.json`:
 
 ```json
 {
-  "RiveRuntimeIOSVersion": "6.18.2"
+  "RiveRuntimeIOSVersion": "6.19.0"
 }
 ```
 
@@ -161,7 +161,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       withPodfileProperties,
       {
-        RiveRuntimeIOSVersion: '6.18.2',
+        RiveRuntimeIOSVersion: '6.19.0',
       },
     ],
     [

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1690,10 +1690,10 @@ PODS:
     - React-logger (= 0.76.7)
     - React-perflogger (= 0.76.7)
     - React-utils (= 0.76.7)
-  - rive-react-native (9.8.1):
+  - rive-react-native (9.8.2):
     - React-Core
-    - RiveRuntime (= 6.18.2)
-  - RiveRuntime (6.18.2)
+    - RiveRuntime (= 6.19.0)
+  - RiveRuntime (6.19.0)
   - RNCPicker (2.11.0):
     - DoubleConversion
     - glog
@@ -2222,8 +2222,8 @@ SPEC CHECKSUMS:
   React-utils: 0342746d2cf989cf5e0d1b84c98cfa152edbdf3f
   ReactCodegen: e1c019dc68733dd2c5d3b263b4a6dc72002c0045
   ReactCommon: 81e0744ee33adfd6d586141b927024f488bc49ea
-  rive-react-native: 42e74b37776e61588e28acb1e3066f37fdd55bbd
-  RiveRuntime: 55c7a7badd9a8389d20fc8a75b7c6accc851b69a
+  rive-react-native: ce5b6eafb3d59cda4cf3c80217df4b14263ee8c4
+  RiveRuntime: 72daf4566aad6e3d0aa9f7fb3e750cbc393ee161
   RNCPicker: c657bd58a82b164a957812f82a0b4bab4245de2e
   RNGestureHandler: 16ef3dc2d7ecb09f240f25df5255953c4098819b
   RNReanimated: a2692304a6568bc656c04c8ffea812887d37436e

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rive-react-native",
   "version": "9.8.2",
   "runtimeVersions": {
-    "ios": "6.18.2",
+    "ios": "6.19.0",
     "android": "11.4.0"
   },
   "workspaces": [


### PR DESCRIPTION
Bump iOS Rive runtime from 6.18.2 → 6.19.0.

The new Rive Apple runtime is out of experimental — faster, multi-threaded, Swift-first. See [migration guide](https://rive.app/docs/runtimes/apple/migrating-from-legacy).

Notable changes ([full changelog](https://github.com/rive-app/rive-ios/releases/tag/6.19.0)):
- fix: create new render path if a path is used multiple times in the same frame
- fix: include BlobAsset in File::read() asset import
- fix: look for view model properties by name and type
- fix(runtime): advance view models from bindable artboards
- feat: Rive Renderer in Recorder
- feat: single/multiline support in TextInput and improved scrolling