### PR TITLE
fix(Android): bump runtime to 11.4.1 to fix ARMv7 TLS relocation crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ By default, `rive-react-native` uses the native SDK versions specified in `packa
 ```json
 "runtimeVersions": {
   "ios": "6.18.2",
-  "android": "11.4.0"
+  "android": "11.4.1"
 }
 ```
 
@@ -143,7 +143,7 @@ cd ios && pod install
 Add to `android/gradle.properties`:
 
 ```properties
-Rive_RiveRuntimeAndroidVersion=11.4.0
+Rive_RiveRuntimeAndroidVersion=11.4.1
 ```
 
 #### Expo Projects
@@ -167,7 +167,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       withGradleProperties,
       {
-        Rive_RiveRuntimeAndroidVersion: '11.4.0',
+        Rive_RiveRuntimeAndroidVersion: '11.4.1',
       },
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "9.8.2",
   "runtimeVersions": {
     "ios": "6.18.2",
-    "android": "11.4.0"
+    "android": "11.4.1"
   },
   "workspaces": [
     "example"


### PR DESCRIPTION
Bumps the default Android runtime from 11.4.0 to 11.4.1.

rive-android 11.4.1 includes the fix [`4b3c801`](https://github.com/rive-app/rive-android/commit/4b3c8013b64e035457b6d50d1fd99ba44fae6127) ("Fix linking issues on ARMv7 devices due to TLS relocations"), which resolves an `UnsatisfiedLinkError` at `Rive.init` on Android 9 / API 28 caused by `R_ARM_TLS_DTPMOD32` (reloc type 17) relocations that the API 28 linker cannot resolve. Apps using rive-android >= 11.0.0 crash at startup on affected devices when Rive is initialized in `Application.onCreate`.

## Changes

- `package.json`: `runtimeVersions.android` `11.4.0` -> `11.4.1`
- `README.md`: update the three `11.4.0` references (defaults block, `gradle.properties` snippet, Expo `withGradleProperties` snippet) to `11.4.1`

## Test plan

- [ ] Verify example app builds and runs on Android with the bumped runtime
- [ ] Verify no startup crash on an Android 9 / API 28 ARMv7 device or emulator