### PR TITLE
chore: bump native runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ By default, `rive-react-native` uses the native SDK versions specified in `packa
 
 ```json
 "runtimeVersions": {
-  "ios": "6.18.2",
-  "android": "11.4.1"
+  "ios": "6.21.0",
+  "android": "11.7.1"
 }
 ```
 
@@ -128,7 +128,7 @@ Create or edit `ios/Podfile.properties.json`:
 
 ```json
 {
-  "RiveRuntimeIOSVersion": "6.18.2"
+  "RiveRuntimeIOSVersion": "6.21.0"
 }
 ```
 
@@ -143,7 +143,7 @@ cd ios && pod install
 Add to `android/gradle.properties`:
 
 ```properties
-Rive_RiveRuntimeAndroidVersion=11.4.1
+Rive_RiveRuntimeAndroidVersion=11.7.1
 ```
 
 #### Expo Projects
@@ -161,13 +161,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       withPodfileProperties,
       {
-        RiveRuntimeIOSVersion: '6.18.2',
+        RiveRuntimeIOSVersion: '6.21.0',
       },
     ],
     [
       withGradleProperties,
       {
-        Rive_RiveRuntimeAndroidVersion: '11.4.1',
+        Rive_RiveRuntimeAndroidVersion: '11.7.1',
       },
     ],
   ],

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ By default, `rive-react-native` uses the native SDK versions specified in `packa
 
 ```json
 "runtimeVersions": {
-  "ios": "6.21.0",
-  "android": "11.7.1"
+  "ios": "6.21.1",
+  "android": "11.7.2"
 }
 ```
 
@@ -128,7 +128,7 @@ Create or edit `ios/Podfile.properties.json`:
 
 ```json
 {
-  "RiveRuntimeIOSVersion": "6.21.0"
+  "RiveRuntimeIOSVersion": "6.21.1"
 }
 ```
 
@@ -143,7 +143,7 @@ cd ios && pod install
 Add to `android/gradle.properties`:
 
 ```properties
-Rive_RiveRuntimeAndroidVersion=11.7.1
+Rive_RiveRuntimeAndroidVersion=11.7.2
 ```
 
 #### Expo Projects
@@ -161,13 +161,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       withPodfileProperties,
       {
-        RiveRuntimeIOSVersion: '6.21.0',
+        RiveRuntimeIOSVersion: '6.21.1',
       },
     ],
     [
       withGradleProperties,
       {
-        Rive_RiveRuntimeAndroidVersion: '11.7.1',
+        Rive_RiveRuntimeAndroidVersion: '11.7.2',
       },
     ],
   ],

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1690,10 +1690,10 @@ PODS:
     - React-logger (= 0.76.7)
     - React-perflogger (= 0.76.7)
     - React-utils (= 0.76.7)
-  - rive-react-native (9.8.1):
+  - rive-react-native (9.8.3):
     - React-Core
-    - RiveRuntime (= 6.18.2)
-  - RiveRuntime (6.18.2)
+    - RiveRuntime (= 6.21.0)
+  - RiveRuntime (6.21.0)
   - RNCPicker (2.11.0):
     - DoubleConversion
     - glog
@@ -2163,7 +2163,7 @@ SPEC CHECKSUMS:
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: eb4a80f6bf578536c58a44198ec93a30f6e69218
-  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
+  RCT-Folly: 84578c8756030547307e4572ab1947de1685c599
   RCTDeprecation: 7691283dd69fed46f6653d376de6fa83aaad774c
   RCTRequired: eac044a04629288f272ee6706e31f81f3a2b4bfe
   RCTTypeSafety: cfe499e127eda6dd46e5080e12d80d0bfe667228
@@ -2222,14 +2222,14 @@ SPEC CHECKSUMS:
   React-utils: 0342746d2cf989cf5e0d1b84c98cfa152edbdf3f
   ReactCodegen: e1c019dc68733dd2c5d3b263b4a6dc72002c0045
   ReactCommon: 81e0744ee33adfd6d586141b927024f488bc49ea
-  rive-react-native: 42e74b37776e61588e28acb1e3066f37fdd55bbd
-  RiveRuntime: 55c7a7badd9a8389d20fc8a75b7c6accc851b69a
+  rive-react-native: 0cf7294ed5f19bacc47c25eeb5b76deafcd66c38
+  RiveRuntime: 2ebd6283418b35579018227eb19ffbd4a377cbba
   RNCPicker: c657bd58a82b164a957812f82a0b4bab4245de2e
   RNGestureHandler: 16ef3dc2d7ecb09f240f25df5255953c4098819b
   RNReanimated: a2692304a6568bc656c04c8ffea812887d37436e
   RNScreens: 351f431ef2a042a1887d4d90e1c1024b8ae9d123
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 88e46d0f2096eb9762a82c2c45ab23b0880de97d
+  Yoga: 90d80701b27946c4b23461c00a7207f300a6ff71
 
 PODFILE CHECKSUM: 7111cb0109850378b078b31993e62f5f22d4dcde
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1692,8 +1692,8 @@ PODS:
     - React-utils (= 0.76.7)
   - rive-react-native (9.8.3):
     - React-Core
-    - RiveRuntime (= 6.21.0)
-  - RiveRuntime (6.21.0)
+    - RiveRuntime (= 6.21.1)
+  - RiveRuntime (6.21.1)
   - RNCPicker (2.11.0):
     - DoubleConversion
     - glog
@@ -2222,8 +2222,8 @@ SPEC CHECKSUMS:
   React-utils: 0342746d2cf989cf5e0d1b84c98cfa152edbdf3f
   ReactCodegen: e1c019dc68733dd2c5d3b263b4a6dc72002c0045
   ReactCommon: 81e0744ee33adfd6d586141b927024f488bc49ea
-  rive-react-native: 0cf7294ed5f19bacc47c25eeb5b76deafcd66c38
-  RiveRuntime: 2ebd6283418b35579018227eb19ffbd4a377cbba
+  rive-react-native: e35a364b750c585d80db9b5ef3f0b9a03b004f7c
+  RiveRuntime: b762bd437b7de47d34d0f8e670112d0b9143f8d6
   RNCPicker: c657bd58a82b164a957812f82a0b4bab4245de2e
   RNGestureHandler: 16ef3dc2d7ecb09f240f25df5255953c4098819b
   RNReanimated: a2692304a6568bc656c04c8ffea812887d37436e

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "rive-react-native",
   "version": "9.8.3",
   "runtimeVersions": {
-    "ios": "6.18.2",
-    "android": "11.4.1"
+    "ios": "6.21.0",
+    "android": "11.7.1"
   },
   "workspaces": [
     "example"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "rive-react-native",
   "version": "9.8.3",
   "runtimeVersions": {
-    "ios": "6.21.0",
-    "android": "11.7.1"
+    "ios": "6.21.1",
+    "android": "11.7.2"
   },
   "workspaces": [
     "example"


### PR DESCRIPTION
Bump the pinned native runtimes to the latest releases.

- iOS: 6.18.2 -> 6.21.1
- Android: 11.4.1 -> 11.7.2

Also updates README runtime version examples to match package.json defaults and refreshes example/ios/Podfile.lock by running pod update RiveRuntime.