### PR TITLE
fix: pin npm to v11 as latest compatible version for our node runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - run: yarn install --immutable
 


### PR DESCRIPTION
Same fix as rive-app/rive-nitro-react-native#340: npm v12 dropped support for the Node version pinned in `.nvmrc` (v20.19.0, npm 12 requires Node >=22.22.2), so the `npm install -g npm@latest` step in the publish workflow fails with `EBADENGINE`. This is why the v9.8.4 publish run failed and 9.8.4 never reached npm. Pinning to npm v11 (which still has OIDC support, since 11.5.1) unblocks publishing; updating `.nvmrc` can be looked at separately.

Note: since the v9.8.4 tag predates this fix, re-running that publish won't pick it up — the next release (9.8.5) will publish cleanly and carry the 9.8.4 changes.