### PR TITLE
chore: bump native runtimes (iOS 6.23.1, Android 11.9.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ By default, `rive-react-native` uses the native SDK versions specified in `packa
 
 ```json
 "runtimeVersions": {
-  "ios": "6.21.1",
-  "android": "11.7.2"
+  "ios": "6.23.1",
+  "android": "11.9.1"
 }
 ```
 
@@ -128,7 +128,7 @@ Create or edit `ios/Podfile.properties.json`:
 
 ```json
 {
-  "RiveRuntimeIOSVersion": "6.21.1"
+  "RiveRuntimeIOSVersion": "6.23.1"
 }
 ```
 
@@ -143,7 +143,7 @@ cd ios && pod install
 Add to `android/gradle.properties`:
 
 ```properties
-Rive_RiveRuntimeAndroidVersion=11.7.2
+Rive_RiveRuntimeAndroidVersion=11.9.1
 ```
 
 #### Expo Projects
@@ -161,13 +161,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       withPodfileProperties,
       {
-        RiveRuntimeIOSVersion: '6.21.1',
+        RiveRuntimeIOSVersion: '6.23.1',
       },
     ],
     [
       withGradleProperties,
       {
-        Rive_RiveRuntimeAndroidVersion: '11.7.2',
+        Rive_RiveRuntimeAndroidVersion: '11.9.1',
       },
     ],
   ],

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1690,10 +1690,10 @@ PODS:
     - React-logger (= 0.76.7)
     - React-perflogger (= 0.76.7)
     - React-utils (= 0.76.7)
-  - rive-react-native (9.8.3):
+  - rive-react-native (9.8.5):
     - React-Core
-    - RiveRuntime (= 6.21.1)
-  - RiveRuntime (6.21.1)
+    - RiveRuntime (= 6.23.1)
+  - RiveRuntime (6.23.1)
   - RNCPicker (2.11.0):
     - DoubleConversion
     - glog
@@ -2222,8 +2222,8 @@ SPEC CHECKSUMS:
   React-utils: 0342746d2cf989cf5e0d1b84c98cfa152edbdf3f
   ReactCodegen: e1c019dc68733dd2c5d3b263b4a6dc72002c0045
   ReactCommon: 81e0744ee33adfd6d586141b927024f488bc49ea
-  rive-react-native: e35a364b750c585d80db9b5ef3f0b9a03b004f7c
-  RiveRuntime: b762bd437b7de47d34d0f8e670112d0b9143f8d6
+  rive-react-native: 91b6bad244eb8cfe0cb6c97158c5b4280b450754
+  RiveRuntime: b544ffc5191ae20ce96f51f44955b3e5c515a518
   RNCPicker: c657bd58a82b164a957812f82a0b4bab4245de2e
   RNGestureHandler: 16ef3dc2d7ecb09f240f25df5255953c4098819b
   RNReanimated: a2692304a6568bc656c04c8ffea812887d37436e

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "rive-react-native",
   "version": "9.8.5",
   "runtimeVersions": {
-    "ios": "6.21.1",
-    "android": "11.7.2"
+    "ios": "6.23.1",
+    "android": "11.9.1"
   },
   "workspaces": [
     "example"


### PR DESCRIPTION
Bumps the underlying Rive runtimes from iOS 6.21.1 to 6.23.1 and Android 11.7.2 to 11.9.1 in `package.json` `runtimeVersions`, which is what the podspec and `android/build.gradle` resolve against. Also refreshes `example/ios/Podfile.lock` via `pod install` and the version examples in the README.

Verified locally that the example app builds on iOS against RiveRuntime 6.23.1.