### PR TITLE
fix: bump native runtimes to iOS 6.24.0 and Android 11.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ By default, `rive-react-native` uses the native SDK versions specified in `packa
 
 ```json
 "runtimeVersions": {
-  "ios": "6.23.1",
-  "android": "11.9.1"
+  "ios": "6.24.0",
+  "android": "11.10.0"
 }
 ```
 
@@ -128,7 +128,7 @@ Create or edit `ios/Podfile.properties.json`:
 
 ```json
 {
-  "RiveRuntimeIOSVersion": "6.23.1"
+  "RiveRuntimeIOSVersion": "6.24.0"
 }
 ```
 
@@ -143,7 +143,7 @@ cd ios && pod install
 Add to `android/gradle.properties`:
 
 ```properties
-Rive_RiveRuntimeAndroidVersion=11.9.1
+Rive_RiveRuntimeAndroidVersion=11.10.0
 ```
 
 #### Expo Projects
@@ -161,13 +161,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       withPodfileProperties,
       {
-        RiveRuntimeIOSVersion: '6.23.1',
+        RiveRuntimeIOSVersion: '6.24.0',
       },
     ],
     [
       withGradleProperties,
       {
-        Rive_RiveRuntimeAndroidVersion: '11.9.1',
+        Rive_RiveRuntimeAndroidVersion: '11.10.0',
       },
     ],
   ],

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1692,8 +1692,8 @@ PODS:
     - React-utils (= 0.76.7)
   - rive-react-native (9.8.5):
     - React-Core
-    - RiveRuntime (= 6.23.1)
-  - RiveRuntime (6.23.1)
+    - RiveRuntime (= 6.24.0)
+  - RiveRuntime (6.24.0)
   - RNCPicker (2.11.0):
     - DoubleConversion
     - glog
@@ -2222,8 +2222,8 @@ SPEC CHECKSUMS:
   React-utils: 0342746d2cf989cf5e0d1b84c98cfa152edbdf3f
   ReactCodegen: e1c019dc68733dd2c5d3b263b4a6dc72002c0045
   ReactCommon: 81e0744ee33adfd6d586141b927024f488bc49ea
-  rive-react-native: 91b6bad244eb8cfe0cb6c97158c5b4280b450754
-  RiveRuntime: b544ffc5191ae20ce96f51f44955b3e5c515a518
+  rive-react-native: 5c5234c1d564c6a3cad709bb55d6b2a9d511849c
+  RiveRuntime: 34b1681a20b64bfb549f210fe7365fafb9321b8a
   RNCPicker: c657bd58a82b164a957812f82a0b4bab4245de2e
   RNGestureHandler: 16ef3dc2d7ecb09f240f25df5255953c4098819b
   RNReanimated: a2692304a6568bc656c04c8ffea812887d37436e

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "rive-react-native",
   "version": "9.8.5",
   "runtimeVersions": {
-    "ios": "6.23.1",
-    "android": "11.9.1"
+    "ios": "6.24.0",
+    "android": "11.10.0"
   },
   "workspaces": [
     "example"


### PR DESCRIPTION
Picks up the newer native releases Gordon mentioned on #442: iOS 6.23.1 to 6.24.0 and Android 11.9.1 to 11.10.0, both the latest published.

Versions live in `package.json` `runtimeVersions`, which the podspec and `android/build.gradle` resolve against. `example/ios/Podfile.lock` is refreshed via `pod update RiveRuntime`, and the README version examples are updated to match.

Uses a `fix:` prefix so release-please plans a release. The 6.23.1 / 11.9.1 bump in #438 landed as `chore:` and is still unreleased, so this release will cover both bumps.

Verified locally: the example app builds on iOS against RiveRuntime 6.24.0, and the Android library builds against `app.rive:rive-android:11.10.0`.